### PR TITLE
Build App: Scene base class

### DIFF
--- a/src/core/scene_base.py
+++ b/src/core/scene_base.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+import arcade
+
+logger = logging.getLogger(__name__)
+
+
+class SceneBase(arcade.View):
+    """
+    Base class for all game views/scenes.
+
+    Responsibilities:
+    - Viewport handling to avoid flicker on initial show and window resize.
+    - Maintain separate world and UI cameras and keep them in sync with the window size.
+    - Provide a utility to draw centered text on the UI layer.
+
+    Usage:
+    - Inherit this class for all views (Title, Graveyard, Dungeon, Combat, etc.)
+    - Call self.ui_camera.use() to draw UI, and self.world_camera.use() to draw world.
+    - Implement on_draw, on_update, input handlers in child classes as needed.
+
+    Notes on flicker:
+    - Arcade can briefly flicker during window resize if the viewport isn't updated promptly.
+      This base class updates the viewport immediately in on_show_view and on_resize to
+      prevent that.
+    """
+
+    def __init__(
+        self,
+        background_color: Tuple[int, int, int] = arcade.color.BLACK,
+        default_font_name: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.background_color = background_color
+        self.default_font_name = default_font_name
+
+        # Cameras are created lazily once a window is available
+        self.world_camera: Optional[arcade.Camera] = None
+        self.ui_camera: Optional[arcade.Camera] = None
+
+    # ---------------------
+    # Lifecycle / Viewport
+    # ---------------------
+    def on_show_view(self) -> None:  # arcade callback
+        """Called when this view is shown by the window.
+
+        Ensures cameras are created and viewport is applied immediately to avoid flicker.
+        """
+        logger.debug("SceneBase.on_show_view()")
+
+        # Set the background before drawing to avoid any visual tearing/flicker.
+        if self.background_color is not None:
+            arcade.set_background_color(self.background_color)
+
+        # Ensure cameras exist and match the current window size
+        self._ensure_cameras()
+
+        # Ensure the viewport exactly matches the window pixel size
+        self._apply_viewport()
+
+    def on_resize(self, width: int, height: int) -> None:  # arcade callback
+        """Handle window resize without flicker.
+
+        Resizes both world and UI cameras, and reapplies the viewport so the content
+        matches new dimensions.
+        """
+        logger.debug("SceneBase.on_resize(width=%d, height=%d)", width, height)
+
+        # If cameras aren't created yet (edge case), create them now
+        if self.world_camera is None or self.ui_camera is None:
+            self._ensure_cameras()
+
+        # Resize cameras to the new window size
+        if self.world_camera is not None:
+            self.world_camera.resize(width, height)
+        if self.ui_camera is not None:
+            self.ui_camera.resize(width, height)
+
+        # Update viewport immediately to prevent flicker
+        self._apply_viewport(width, height)
+
+    # ---------------------
+    # Drawing Helpers
+    # ---------------------
+    def draw_centered_text(
+        self,
+        text: str,
+        *,
+        center_x: Optional[float] = None,
+        center_y: Optional[float] = None,
+        font_size: float = 24,
+        color: Tuple[int, int, int] = arcade.color.WHITE,
+        font_name: Optional[str] = None,
+        bold: bool = False,
+    ) -> None:
+        """Draw text centered at the given UI position (or screen center by default).
+
+        By default, draws to the UI space, so call self.ui_camera.use() beforehand
+        if you are switching between world and UI drawing.
+        """
+        win = self.window
+        if win is None:
+            raise RuntimeError("SceneBase.draw_centered_text called before window is set.")
+
+        cx = center_x if center_x is not None else win.width / 2
+        cy = center_y if center_y is not None else win.height / 2
+
+        arcade.draw_text(
+            text,
+            cx,
+            cy,
+            color=color,
+            font_size=font_size,
+            font_name=font_name or self.default_font_name,
+            anchor_x="center",
+            anchor_y="center",
+            bold=bold,
+        )
+
+    # ---------------------
+    # Convenience API
+    # ---------------------
+    @property
+    def size(self) -> Tuple[int, int]:
+        """Return current window size as (width, height)."""
+        if self.window is None:
+            return 0, 0
+        return int(self.window.width), int(self.window.height)
+
+    def use_world(self) -> None:
+        """Activate the world camera for world-space drawing."""
+        self._ensure_cameras()
+        assert self.world_camera is not None
+        self.world_camera.use()
+
+    def use_ui(self) -> None:
+        """Activate the UI camera for screen-space drawing."""
+        self._ensure_cameras()
+        assert self.ui_camera is not None
+        self.ui_camera.use()
+
+    # ---------------------
+    # Internal Utilities
+    # ---------------------
+    def _ensure_cameras(self) -> None:
+        """Create cameras if they don't exist yet, using the current window size."""
+        win = self.window
+        if win is None:
+            # When running tests or before the view is shown, window can be None.
+            # Defer camera creation until a window is available.
+            logger.debug("_ensure_cameras skipped: window is None")
+            return
+
+        if self.world_camera is None:
+            logger.debug("Creating world_camera with size (%d, %d)", win.width, win.height)
+            self.world_camera = arcade.Camera(win.width, win.height)
+        if self.ui_camera is None:
+            logger.debug("Creating ui_camera with size (%d, %d)", win.width, win.height)
+            self.ui_camera = arcade.Camera(win.width, win.height)
+
+    def _apply_viewport(self, width: Optional[int] = None, height: Optional[int] = None) -> None:
+        """Apply a pixel-perfect viewport matching the window size.
+
+        Explicitly setting the viewport on show and resize prevents resize flicker.
+        """
+        win = self.window
+        if win is None:
+            logger.debug("_apply_viewport skipped: window is None")
+            return
+
+        w = int(width if width is not None else win.width)
+        h = int(height if height is not None else win.height)
+        # Arcade expects left, right, bottom, top in window coordinates
+        arcade.set_viewport(0, w, 0, h)
+        logger.debug("Viewport applied: left=0 right=%d bottom=0 top=%d", w, h)

--- a/tests/test_scene_base.py
+++ b/tests/test_scene_base.py
@@ -1,0 +1,139 @@
+import os
+import types
+
+# Ensure pyglet/arcade operate in headless mode during tests
+os.environ.setdefault("PYGLET_HEADLESS", "true")
+
+import builtins
+import importlib
+import sys
+import pytest
+
+# Ensure src/ is importable
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC = os.path.join(ROOT, "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+
+class MockWindow:
+    def __init__(self, width: int, height: int):
+        self.width = width
+        self.height = height
+
+
+class FakeCamera:
+    def __init__(self, width, height):
+        self.created_with = (int(width), int(height))
+        self._size = (int(width), int(height))
+        self.resized_to = []
+
+    def resize(self, width, height):
+        self._size = (int(width), int(height))
+        self.resized_to.append(self._size)
+
+    def use(self):
+        # No-op for tests
+        pass
+
+
+@pytest.fixture(autouse=True)
+def isolate_arcade(monkeypatch):
+    """Monkeypatch arcade functions used by SceneBase to avoid GL usage and to observe calls."""
+    import arcade
+
+    # Intercept set_viewport to capture last values
+    calls = {"set_viewport": []}
+
+    def fake_set_viewport(left, right, bottom, top):
+        calls["set_viewport"].append((left, right, bottom, top))
+
+    # Intercept draw_text so that calling draw_centered_text won't require a GL context
+    def fake_draw_text(*args, **kwargs):
+        calls.setdefault("draw_text", []).append((args, kwargs))
+
+    monkeypatch.setattr(arcade, "set_viewport", fake_set_viewport)
+    monkeypatch.setattr(arcade, "draw_text", fake_draw_text)
+    # Replace Camera class with our fake, but do it on the module under test for reliability
+    # We'll apply this in a later fixture after importing the module.
+
+    yield calls
+
+
+@pytest.fixture
+def scene_base_module(monkeypatch):
+    # Import the module, then replace its arcade.Camera with our FakeCamera
+    import core.scene_base as scene_base
+    monkeypatch.setattr(scene_base.arcade, "Camera", FakeCamera)
+    return scene_base
+
+
+def test_on_show_view_applies_viewport_and_creates_cameras(isolate_arcade, scene_base_module):
+    SceneBase = scene_base_module.SceneBase
+    view = SceneBase()
+    view.window = MockWindow(1280, 720)
+
+    view.on_show_view()
+
+    # Cameras should be created
+    assert view.world_camera is not None
+    assert view.ui_camera is not None
+
+    # Viewport should be applied to window size
+    assert isolate_arcade["set_viewport"], "set_viewport must be called"
+    left, right, bottom, top = isolate_arcade["set_viewport"][-1]
+    assert (left, right, bottom, top) == (0, 1280, 0, 720)
+
+
+def test_on_resize_updates_cameras_and_viewport(isolate_arcade, scene_base_module):
+    SceneBase = scene_base_module.SceneBase
+    view = SceneBase()
+    view.window = MockWindow(800, 600)
+
+    # Initialize via on_show_view (creates cameras using initial size)
+    view.on_show_view()
+
+    # Resize window
+    view.window.width = 1024
+    view.window.height = 768
+
+    view.on_resize(1024, 768)
+
+    # Our FakeCamera tracks resize calls
+    assert isinstance(view.world_camera, FakeCamera)
+    assert isinstance(view.ui_camera, FakeCamera)
+
+    assert view.world_camera.resized_to[-1] == (1024, 768)
+    assert view.ui_camera.resized_to[-1] == (1024, 768)
+
+    # And viewport should be reapplied
+    assert isolate_arcade["set_viewport"], "set_viewport must be called"
+    left, right, bottom, top = isolate_arcade["set_viewport"][-1]
+    assert (left, right, bottom, top) == (0, 1024, 0, 768)
+
+
+def test_draw_centered_text_uses_window_center(isolate_arcade, scene_base_module):
+    SceneBase = scene_base_module.SceneBase
+    view = SceneBase()
+    view.window = MockWindow(1920, 1080)
+
+    # Ensure cameras created to mimic normal flow
+    view.on_show_view()
+
+    # Activate UI camera (no-op fake)
+    view.use_ui()
+
+    # Draw centered text; with our fake draw_text, this shouldn't require GL
+    view.draw_centered_text("Hello")
+
+    assert "draw_text" in isolate_arcade
+    args, kwargs = isolate_arcade["draw_text"][-1]
+
+    # Args: (text, x, y, ...); text should match, x and y should be center
+    assert args[0] == "Hello"
+    assert pytest.approx(args[1]) == 960  # center_x
+    assert pytest.approx(args[2]) == 540  # center_y
+
+    # Anchors should be center/center
+    assert kwargs.get("anchor_x") == "center"
+    assert kwargs.get("anchor_y") == "center"


### PR DESCRIPTION
Automated implementation for issue #21:

Implementation overview:
- Created src/core/scene_base.py defining SceneBase, a base class for all game views built on arcade.View. It centralizes viewport handling and provides a helper for drawing centered text.
- Viewport handling: SceneBase ensures a pixel-perfect viewport is applied in on_show_view and on_resize by calling arcade.set_viewport(0, window.width, 0, window.height). This prevents the typical flicker that can occur during window resizing.
- Camera management: The class maintains world_camera and ui_camera (arcade.Camera). They are created lazily when a window is available, resized appropriately in on_resize, and can be activated via use_world() and use_ui() methods. This supports a clean separation between world-space and UI drawing.
- Centered text helper: draw_centered_text draws text anchored at the center by default, using the window center if no coordinates are provided. It accepts font, size, color, and bold parameters.
- Tests: Added tests that run headlessly (PYGLET_HEADLESS=true) and monkeypatch arcade to avoid requiring an OpenGL context. Tests verify that:
  1) on_show_view creates cameras and applies the correct viewport; 
  2) on_resize resizes cameras and reapplies the viewport; 
  3) draw_centered_text computes the correct centered coordinates and anchor settings. A FakeCamera is injected to validate resize calls without GPU access.

Architecture decisions:
- Using two cameras (world and UI) standardizes rendering and simplifies future scene implementations. UI drawing can remain resolution-independent while world drawing can apply its own transforms later.
- Viewport updates are centralized to guarantee consistent behavior and avoid flicker across all views.
- The base provides lightweight convenience methods (size, use_world, use_ui), but leaves actual drawing and updating to child classes for flexibility.

Integration points:
- All existing and new views should inherit from core.scene_base.SceneBase instead of arcade.View. Existing on_draw implementations should begin by selecting the appropriate camera (self.world_camera.use() and/or self.ui_camera.use()).
- Optionally, set a custom background_color and default_font_name when initializing the scene.
- To display centered UI messages (e.g., loading screens, pause overlays), call self.use_ui() then self.draw_centered_text(...).


Files created:
- src/core/scene_base.py
- tests/test_scene_base.py