### PR TITLE
Build App: Save & Quit snapshot (later)

### DIFF
--- a/src/amor/__init__.py
+++ b/src/amor/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+# Bump this when making save schema changes and consider bumping schema_version
+__version__ = "0.1.0"

--- a/src/amor/models/run_state.py
+++ b/src/amor/models/run_state.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class Character:
+    """Minimal character representation for snapshotting.
+
+    Extend as needed; keep to primitives or nested dataclasses with to_dict.
+    """
+
+    name: str
+    level: int
+    hp: int
+    max_hp: int
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("Character name cannot be empty")
+        if self.level < 1:
+            raise ValueError("Character level must be >= 1")
+        if self.max_hp <= 0:
+            raise ValueError("Character max_hp must be > 0")
+        if not (0 <= self.hp <= self.max_hp):
+            raise ValueError("Character hp must be within [0, max_hp]")
+
+    def to_dict(self) -> Dict[str, Any]:
+        self.validate()
+        return dataclasses.asdict(self)
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "Character":
+        c = Character(
+            name=str(data["name"]),
+            level=int(data["level"]),
+            hp=int(data["hp"]),
+            max_hp=int(data["max_hp"]),
+        )
+        c.validate()
+        return c
+
+
+@dataclass
+class Party:
+    """Party container for snapshotting mid-run."""
+
+    members: List[Character] = field(default_factory=list)
+
+    def validate(self) -> None:
+        if len(self.members) == 0:
+            raise ValueError("Party must have at least 1 member")
+        for m in self.members:
+            m.validate()
+
+    def to_dict(self) -> Dict[str, Any]:
+        self.validate()
+        return {"members": [m.to_dict() for m in self.members]}
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "Party":
+        members = [Character.from_dict(m) for m in data.get("members", [])]
+        p = Party(members=members)
+        p.validate()
+        return p
+
+
+@dataclass
+class RunState:
+    """Minimal run state for volatile snapshot save-and-quit.
+
+    This is not the full persistent save; it is a volatile snapshot consumed on load.
+    Acceptance criteria requires: restores party, floor, seed.
+    """
+
+    floor: int
+    dungeon_seed: int
+    party: Party
+    # Additional fields can be added as needed, e.g., inventory, timers, etc.
+
+    def validate(self) -> None:
+        if not isinstance(self.floor, int) or self.floor < 1:
+            raise ValueError("floor must be >= 1")
+        if not isinstance(self.dungeon_seed, int):
+            raise ValueError("dungeon_seed must be an int")
+        self.party.validate()
+
+    def to_dict(self) -> Dict[str, Any]:
+        self.validate()
+        return {
+            "floor": self.floor,
+            "dungeon_seed": self.dungeon_seed,
+            "party": self.party.to_dict(),
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "RunState":
+        rs = RunState(
+            floor=int(data["floor"]),
+            dungeon_seed=int(data["dungeon_seed"]),
+            party=Party.from_dict(data["party"]),
+        )
+        rs.validate()
+        return rs
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+    @staticmethod
+    def from_json(s: str) -> "RunState":
+        return RunState.from_dict(json.loads(s))

--- a/src/amor/save/snapshot.py
+++ b/src/amor/save/snapshot.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import json
+import logging
+import os
+import pickle
+import random
+from pathlib import Path
+from typing import Optional, Tuple
+
+from platformdirs import PlatformDirs
+
+from .. import __version__
+from ..models.run_state import RunState
+from ..utils.crypto import HMACKeyManager, hmac_sign, hmac_verify
+from ..utils.fs import ensure_dir, atomic_write_json
+from ..utils.jsonutil import canonical_dumps
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotError(Exception):
+    pass
+
+
+class SnapshotIntegrityError(SnapshotError):
+    pass
+
+
+class SnapshotDecodeError(SnapshotError):
+    pass
+
+
+class SnapshotManager:
+    """Manages a single volatile run snapshot for save-and-quit.
+
+    Design goals:
+    - Single slot only (prevents scumming via multiple states)
+    - Snapshot is consumed on successful load
+    - Atomic writes to avoid corruption
+    - HMAC over canonical payload to discourage tampering
+
+    Snapshot file schema (JSON):
+    {
+      "schema_version": 1,
+      "slot_id": 1,
+      "created_at": ISO8601,
+      "game_version": str,
+      "run_state": {...},  # RunState JSON
+      "rng_state": str,    # base64-encoded pickle of random.Random state
+      "hmac": str          # hex digest over canonical payload (excludes hmac field)
+    }
+    """
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, *, base_dir: Optional[Path] = None) -> None:
+        if base_dir is None:
+            d = PlatformDirs(appname="AmorMortuorum", appauthor="AmorMortuorumTeam")
+            base_dir = Path(d.user_data_dir)
+        self.base_dir = base_dir
+        self.save_dir = self.base_dir / "saves"
+        self.snapshot_path = self.save_dir / "snapshot.json"
+        self.key_mgr = HMACKeyManager(base_dir=self.base_dir)
+        ensure_dir(self.save_dir)
+
+    def has_snapshot(self) -> bool:
+        return self.snapshot_path.exists()
+
+    def clear_snapshot(self) -> None:
+        try:
+            if self.snapshot_path.exists():
+                self.snapshot_path.unlink()
+        except Exception:
+            logger.warning("Failed to remove snapshot file", exc_info=True)
+
+    def _encode_rng_state(self, rng: random.Random) -> str:
+        s = rng.getstate()
+        b = pickle.dumps(s, protocol=pickle.HIGHEST_PROTOCOL)
+        return base64.b64encode(b).decode("ascii")
+
+    def _decode_rng_state(self, enc: str) -> random.Random:
+        try:
+            b = base64.b64decode(enc.encode("ascii"))
+            s = pickle.loads(b)
+            rng = random.Random()
+            rng.setstate(s)
+            return rng
+        except Exception as e:
+            raise SnapshotDecodeError("Failed to decode RNG state") from e
+
+    def save_snapshot(self, run_state: RunState, rng: random.Random) -> None:
+        """Persist the current run state and PRNG state atomically.
+
+        Intended to be called on explicit save-and-quit.
+        """
+        run_state.validate()
+        key = self.key_mgr.get_or_create_key()
+        payload = {
+            "schema_version": self.SCHEMA_VERSION,
+            "slot_id": 1,
+            "created_at": dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat(),
+            "game_version": __version__,
+            "run_state": run_state.to_dict(),
+            "rng_state": self._encode_rng_state(rng),
+        }
+        payload_bytes = canonical_dumps(payload).encode("utf-8")
+        digest_hex = hmac_sign(payload_bytes, key)
+        snapshot = dict(payload)
+        snapshot["hmac"] = digest_hex
+        atomic_write_json(self.snapshot_path, snapshot)
+        logger.info("Saved volatile snapshot to %s", self.snapshot_path)
+
+    def _read_snapshot(self) -> dict:
+        try:
+            raw = self.snapshot_path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+            return data
+        except Exception as e:
+            raise SnapshotDecodeError("Failed to read snapshot file") from e
+
+    def _verify_snapshot(self, data: dict) -> None:
+        key = self.key_mgr.get_or_create_key()
+        if data.get("schema_version") != self.SCHEMA_VERSION:
+            raise SnapshotIntegrityError("Unsupported snapshot schema version")
+        if data.get("slot_id") != 1:
+            raise SnapshotIntegrityError("Invalid snapshot slot id")
+        digest_hex = data.get("hmac")
+        if not isinstance(digest_hex, str):
+            raise SnapshotIntegrityError("Missing snapshot HMAC")
+        payload = {k: v for k, v in data.items() if k != "hmac"}
+        if not hmac_verify(canonical_dumps(payload).encode("utf-8"), key, digest_hex):
+            raise SnapshotIntegrityError("Snapshot HMAC verification failed")
+
+    def load_snapshot(self) -> Tuple[RunState, random.Random]:
+        """Load and consume the volatile snapshot.
+
+        Returns the RunState and RNG ready to continue the run.
+        On integrity failure or decode error, the snapshot is cleared and an exception raised.
+        """
+        if not self.snapshot_path.exists():
+            raise SnapshotError("No snapshot found")
+
+        data = self._read_snapshot()
+        try:
+            self._verify_snapshot(data)
+            run_state = RunState.from_dict(data["run_state"])
+            rng = self._decode_rng_state(data["rng_state"])
+        except Exception:
+            # On any issue, clear snapshot to prevent repeated attempts and scumming
+            self.clear_snapshot()
+            raise
+
+        # Consume snapshot after successfully reconstructing state
+        try:
+            os.remove(self.snapshot_path)
+        except Exception:
+            logger.warning("Failed to delete snapshot after load", exc_info=True)
+
+        logger.info("Loaded and consumed volatile snapshot from %s", self.snapshot_path)
+        return run_state, rng
+
+    def get_snapshot_metadata(self) -> Optional[dict]:
+        if not self.has_snapshot():
+            return None
+        try:
+            data = self._read_snapshot()
+            # Do not verify HMAC here to allow UI to show presence even if invalid; but keep minimal metadata
+            return {
+                "schema_version": data.get("schema_version"),
+                "slot_id": data.get("slot_id"),
+                "created_at": data.get("created_at"),
+                "game_version": data.get("game_version"),
+            }
+        except Exception:
+            return None

--- a/src/amor/utils/crypto.py
+++ b/src/amor/utils/crypto.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from hashlib import sha256
+from pathlib import Path
+from typing import Optional
+
+from platformdirs import PlatformDirs
+
+from .fs import ensure_dir, atomic_write_bytes
+
+logger = logging.getLogger(__name__)
+
+
+class HMACKeyManager:
+    """Manages a per-install HMAC key used to sign volatile snapshots.
+
+    This discourages trivial tampering but is not intended as anti-cheat.
+    """
+
+    def __init__(self, *, base_dir: Optional[Path] = None) -> None:
+        if base_dir is None:
+            d = PlatformDirs(appname="AmorMortuorum", appauthor="AmorMortuorumTeam")
+            base_dir = Path(d.user_data_dir)
+        self.base_dir = base_dir
+        self.sec_dir = self.base_dir / "security"
+        self.key_path = self.sec_dir / "snapshot_hmac.key"
+
+    def get_or_create_key(self) -> bytes:
+        if self.key_path.exists():
+            try:
+                return self.key_path.read_bytes()
+            except Exception:
+                logger.warning("Failed to read HMAC key; regenerating.", exc_info=True)
+        # Generate new 32-byte key
+        ensure_dir(self.sec_dir)
+        key = os.urandom(32)
+        atomic_write_bytes(self.key_path, key)
+        try:
+            os.chmod(self.key_path, 0o600)
+        except Exception:
+            logger.debug("Could not chmod key file", exc_info=True)
+        return key
+
+
+def hmac_sign(payload_bytes: bytes, key: bytes) -> str:
+    return hmac.new(key, payload_bytes, sha256).hexdigest()
+
+
+def hmac_verify(payload_bytes: bytes, key: bytes, digest_hex: str) -> bool:
+    expected = hmac_sign(payload_bytes, key)
+    try:
+        return hmac.compare_digest(expected, digest_hex)
+    except Exception:
+        return False

--- a/src/amor/utils/fs.py
+++ b/src/amor/utils/fs.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_dir(path: Path, *, mode: int = 0o700) -> None:
+    """Ensure directory exists with secure permissions."""
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, mode)
+    except Exception:  # Platform may not support
+        logger.debug("Could not chmod directory: %s", path, exc_info=True)
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Atomically write bytes to a path using a temporary file and replace.
+
+    Ensures that either the old file remains or the new file fully replaces it.
+    """
+    tmp_dir = path.parent
+    ensure_dir(tmp_dir)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name, dir=tmp_dir)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.remove(tmp_name)
+        except Exception:
+            logger.debug("Could not remove temp file %s", tmp_name, exc_info=True)
+
+
+def atomic_write_json(path: Path, obj: Dict[str, Any]) -> None:
+    data = json.dumps(obj, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    atomic_write_bytes(path, data)

--- a/src/amor/utils/jsonutil.py
+++ b/src/amor/utils/jsonutil.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def canonical_dumps(obj: Dict[str, Any]) -> str:
+    """Canonical JSON dump for consistent HMAC signing.
+
+    - No whitespace (compact separators)
+    - Keys sorted
+    """
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True)

--- a/tests/test_run_state_validation.py
+++ b/tests/test_run_state_validation.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from amor.models.run_state import Character, Party, RunState
+
+
+def test_party_and_character_validation() -> None:
+    c = Character(name="Tara", level=2, hp=10, max_hp=12)
+    p = Party(members=[c])
+    rs = RunState(floor=1, dungeon_seed=1, party=p)
+    rs.validate()  # should not raise
+
+    with pytest.raises(ValueError):
+        Character(name="", level=1, hp=1, max_hp=1).validate()
+
+    with pytest.raises(ValueError):
+        Character(name="Joe", level=0, hp=1, max_hp=1).validate()
+
+    with pytest.raises(ValueError):
+        Character(name="Joe", level=1, hp=2, max_hp=1).validate()
+
+    with pytest.raises(ValueError):
+        Party(members=[]).validate()
+
+    with pytest.raises(ValueError):
+        RunState(floor=0, dungeon_seed=1, party=p).validate()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from amor.models.run_state import Character, Party, RunState
+from amor.save.snapshot import (
+    SnapshotIntegrityError,
+    SnapshotManager,
+    SnapshotError,
+)
+
+
+class TempSnapshotEnv:
+    def __init__(self, tmp_path: Path) -> None:
+        self.base_dir = tmp_path / "appdata"
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.mgr = SnapshotManager(base_dir=self.base_dir)
+
+
+def sample_run_state(floor: int = 3, seed: int = 1234) -> RunState:
+    party = Party(
+        members=[
+            Character(name="Aerin", level=4, hp=28, max_hp=30),
+            Character(name="Bran", level=4, hp=35, max_hp=35),
+        ]
+    )
+    return RunState(floor=floor, dungeon_seed=seed, party=party)
+
+
+def test_save_and_load_consumes_snapshot(tmp_path: Path) -> None:
+    env = TempSnapshotEnv(tmp_path)
+    rs = sample_run_state(floor=7, seed=2025)
+    rng = random.Random(99)
+
+    env.mgr.save_snapshot(rs, rng)
+    assert env.mgr.has_snapshot() is True
+
+    loaded_rs, loaded_rng = env.mgr.load_snapshot()
+
+    assert env.mgr.has_snapshot() is False  # consumed on load
+    assert loaded_rs.floor == 7
+    assert loaded_rs.dungeon_seed == 2025
+    assert [m.name for m in loaded_rs.party.members] == ["Aerin", "Bran"]
+    # RNG produces a known next value after load
+    v = loaded_rng.random()
+    assert isinstance(v, float)
+
+
+def test_overwrite_single_slot(tmp_path: Path) -> None:
+    env = TempSnapshotEnv(tmp_path)
+    rng = random.Random(123)
+
+    env.mgr.save_snapshot(sample_run_state(floor=2, seed=111), rng)
+    env.mgr.save_snapshot(sample_run_state(floor=5, seed=222), rng)
+
+    rs2, _ = env.mgr.load_snapshot()
+    assert rs2.floor == 5
+    assert rs2.dungeon_seed == 222
+
+
+def test_hmac_integrity_rejects_tampering(tmp_path: Path) -> None:
+    env = TempSnapshotEnv(tmp_path)
+    rs = sample_run_state(floor=9, seed=909)
+    rng = random.Random(77)
+
+    env.mgr.save_snapshot(rs, rng)
+    # Tamper: change floor without updating HMAC
+    path = env.mgr.snapshot_path
+    data = json.loads(path.read_text())
+    data["run_state"]["floor"] = 99
+    path.write_text(json.dumps(data))
+
+    with pytest.raises(SnapshotIntegrityError):
+        env.mgr.load_snapshot()
+
+    # Snapshot cleared after failure
+    assert env.mgr.has_snapshot() is False
+
+
+def test_rng_state_restored(tmp_path: Path) -> None:
+    env = TempSnapshotEnv(tmp_path)
+    rng1 = random.Random(42)
+
+    # Advance RNG some steps to simulate gameplay
+    _ = [rng1.random() for _ in range(5)]
+
+    rs = sample_run_state(floor=10, seed=4242)
+    env.mgr.save_snapshot(rs, rng1)
+
+    # Expected continuation sequence if we had continued from rng1
+    rng_expected = random.Random(42)
+    _ = [rng_expected.random() for _ in range(5)]
+
+    # Load snapshot and compare next values
+    _, rng_loaded = env.mgr.load_snapshot()
+
+    next_vals_loaded = [rng_loaded.random() for _ in range(3)]
+    next_vals_expected = [rng_expected.random() for _ in range(3)]
+
+    assert next_vals_loaded == next_vals_expected
+
+
+def test_load_without_snapshot_raises(tmp_path: Path) -> None:
+    env = TempSnapshotEnv(tmp_path)
+    with pytest.raises(SnapshotError):
+        env.mgr.load_snapshot()


### PR DESCRIPTION
Automated implementation for issue #25:

Implementation overview:
- Added a production-ready volatile snapshot system to support Save & Quit and later Continue.
- SnapshotManager in src/amor/save/snapshot.py provides APIs to save and load a single-slot, consumed-on-load snapshot containing:
  - RunState (floor, dungeon_seed, party)
  - PRNG state of Python's random.Random to ensure deterministic continuation
  - Metadata (schema_version, created_at, game_version)
  - HMAC signature for integrity using a per-install key
- Anti-scumming approach:
  - Single snapshot slot only
  - Snapshot is consumed (deleted) after a successful load
  - Atomic write ensures no partial files; on failure or tampering, snapshot is cleared
  - While it cannot block out-of-game file backups, it meets the acceptance criteria for non-abusable in normal play.

Architecture decisions:
- Data modeling:
  - RunState/Party/Character dataclasses formalize the minimal mid-run state needed by acceptance criteria and include robust validation and JSON serialization.
- Persistence & integrity:
  - Platform-specific app data directory via platformdirs
  - Atomic save using a temporary file and os.replace for crash safety
  - HMAC-SHA256 over a canonical JSON payload (excluding the hmac field) to detect tampering; key managed per-install under a security directory.
- Determinism:
  - Stores the random.Random state (pickle -> base64) to resume PRNG sequence seamlessly.

Integration points:
- UI can surface a Continue option by calling SnapshotManager.has_snapshot().
- On save-and-quit: call SnapshotManager.save_snapshot(run_state, rng).
- On continue: call SnapshotManager.load_snapshot() to get (run_state, rng). After load, snapshot is consumed automatically.
- get_snapshot_metadata() allows showing simple timestamp/version info for the continue menu without full verification costs.

Testing:
- tests/test_snapshot.py covers save/load consumption, single-slot overwrite, HMAC integrity rejection and clearing, RNG state resumption, and load error when no snapshot exists.
- tests/test_run_state_validation.py verifies validation logic for character/party/run state.

Notes:
- Versioning: schema_version is set to 1; any breaking change should bump this constant and implement migration if needed.
- Security: HMAC discourages casual file edits; it is not a full anti-cheat system.
- Error handling: On decode/verify errors, SnapshotManager clears the snapshot to avoid repetitive attempts and potential scumming.


Files created:
- src/amor/__init__.py
- src/amor/models/run_state.py
- src/amor/utils/fs.py
- src/amor/utils/jsonutil.py
- src/amor/utils/crypto.py
- src/amor/save/snapshot.py
- tests/test_snapshot.py
- tests/test_run_state_validation.py