### PR TITLE
Build App: Hybrid generator: cellular caverns

### DIFF
--- a/src/amor/__init__.py
+++ b/src/amor/__init__.py
@@ -1,0 +1,7 @@
+from .config import GenerationSettings
+from .dungeon.factory import DungeonFactory
+
+__all__ = [
+    "GenerationSettings",
+    "DungeonFactory",
+]

--- a/src/amor/config.py
+++ b/src/amor/config.py
@@ -1,0 +1,76 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class GenerationSettings:
+    """Configuration for dungeon generation.
+
+    Selection is done primarily via environment variable AMOR_DUNGEON_ALGO.
+    Supported values: "bsp" (rooms + corridors) and "cellular" (cellular automata caverns).
+
+    The rest of parameters are algorithm-specific defaults that can be overridden
+    programmatically or via environment variables.
+    """
+
+    # Algorithm selection: "bsp" or "cellular"
+    algorithm: str = "bsp"
+
+    # Global map dimensions
+    width: int = 80
+    height: int = 48
+
+    # Random seed (optional); if None, random randomness is used
+    seed: Optional[int] = None
+
+    # Rooms algorithm (BSP/rooms) parameters
+    max_rooms: int = 18
+    room_min_size: int = 4
+    room_max_size: int = 10
+
+    # Cellular algorithm parameters
+    cell_initial_wall_prob: float = 0.45
+    cell_smooth_steps: int = 5
+    cell_wall_threshold: int = 5
+    cell_min_floor_fraction: float = 0.28
+
+    @staticmethod
+    def from_env() -> "GenerationSettings":
+        """Build settings from environment variables, providing sensible defaults.
+
+        Environment variables:
+          - AMOR_DUNGEON_ALGO: one of {"bsp", "cellular"}
+          - AMOR_WIDTH, AMOR_HEIGHT
+          - AMOR_SEED
+          - AMOR_MAX_ROOMS, AMOR_ROOM_MIN, AMOR_ROOM_MAX
+          - AMOR_CELL_INIT_P, AMOR_CELL_STEPS, AMOR_CELL_T, AMOR_CELL_MIN_F
+        """
+        algo = os.getenv("AMOR_DUNGEON_ALGO", "bsp").strip().lower()
+        width = int(os.getenv("AMOR_WIDTH", 80))
+        height = int(os.getenv("AMOR_HEIGHT", 48))
+        seed_env = os.getenv("AMOR_SEED")
+        seed = int(seed_env) if seed_env not in (None, "", "none", "None") else None
+
+        max_rooms = int(os.getenv("AMOR_MAX_ROOMS", 18))
+        room_min = int(os.getenv("AMOR_ROOM_MIN", 4))
+        room_max = int(os.getenv("AMOR_ROOM_MAX", 10))
+
+        cell_init_p = float(os.getenv("AMOR_CELL_INIT_P", 0.45))
+        cell_steps = int(os.getenv("AMOR_CELL_STEPS", 5))
+        cell_t = int(os.getenv("AMOR_CELL_T", 5))
+        cell_min_f = float(os.getenv("AMOR_CELL_MIN_F", 0.28))
+
+        return GenerationSettings(
+            algorithm=algo,
+            width=width,
+            height=height,
+            seed=seed,
+            max_rooms=max_rooms,
+            room_min_size=room_min,
+            room_max_size=room_max,
+            cell_initial_wall_prob=cell_init_p,
+            cell_smooth_steps=cell_steps,
+            cell_wall_threshold=cell_t,
+            cell_min_floor_fraction=cell_min_f,
+        )

--- a/src/amor/dungeon/__init__.py
+++ b/src/amor/dungeon/__init__.py
@@ -1,0 +1,4 @@
+from .tiles import Tile, MapGrid
+from .factory import DungeonFactory
+
+__all__ = ["Tile", "MapGrid", "DungeonFactory"]

--- a/src/amor/dungeon/factory.py
+++ b/src/amor/dungeon/factory.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import logging
+from typing import Optional
+
+from ..config import GenerationSettings
+from .generator import CellularGenerator, DungeonGenerator, RoomsGenerator
+from .tiles import MapGrid
+
+logger = logging.getLogger(__name__)
+
+
+class DungeonFactory:
+    """Factory to produce dungeons using the selected algorithm.
+
+    Usage:
+      settings = GenerationSettings.from_env()
+      dungeon = DungeonFactory.generate(settings)
+    """
+
+    @staticmethod
+    def build_generator(settings: GenerationSettings) -> DungeonGenerator:
+        algo = (settings.algorithm or "bsp").lower()
+        if algo in ("bsp", "rooms", "bsp_rooms"):
+            logger.info("DungeonFactory: using RoomsGenerator (algorithm=%s)", algo)
+            return RoomsGenerator(
+                max_rooms=settings.max_rooms,
+                room_min_size=settings.room_min_size,
+                room_max_size=settings.room_max_size,
+            )
+        elif algo in ("cellular", "cave", "cavern"):
+            logger.info("DungeonFactory: using CellularGenerator (algorithm=%s)", algo)
+            return CellularGenerator(
+                initial_wall_prob=settings.cell_initial_wall_prob,
+                smooth_steps=settings.cell_smooth_steps,
+                wall_threshold=settings.cell_wall_threshold,
+                min_floor_fraction=settings.cell_min_floor_fraction,
+            )
+        else:
+            logger.warning(
+                "Unknown algorithm '%s', falling back to RoomsGenerator", algo
+            )
+            return RoomsGenerator(
+                max_rooms=settings.max_rooms,
+                room_min_size=settings.room_min_size,
+                room_max_size=settings.room_max_size,
+            )
+
+    @staticmethod
+    def generate(settings: GenerationSettings, seed: Optional[int] = None) -> MapGrid:
+        gen = DungeonFactory.build_generator(settings)
+        return gen.generate(settings.width, settings.height, seed if seed is not None else settings.seed)

--- a/src/amor/dungeon/generator/__init__.py
+++ b/src/amor/dungeon/generator/__init__.py
@@ -1,0 +1,5 @@
+from .base import DungeonGenerator
+from .bsp_rooms import RoomsGenerator
+from .cellular import CellularGenerator
+
+__all__ = ["DungeonGenerator", "RoomsGenerator", "CellularGenerator"]

--- a/src/amor/dungeon/generator/base.py
+++ b/src/amor/dungeon/generator/base.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from ..tiles import MapGrid
+
+
+class DungeonGenerator(ABC):
+    """Abstract base for dungeon generators."""
+
+    @abstractmethod
+    def generate(self, width: int, height: int, seed: Optional[int] = None) -> MapGrid:
+        """Generate a dungeon map."""
+        raise NotImplementedError

--- a/src/amor/dungeon/generator/bsp_rooms.py
+++ b/src/amor/dungeon/generator/bsp_rooms.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+import logging
+import random
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from ..tiles import MapGrid, Tile
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Rect:
+    x: int
+    y: int
+    w: int
+    h: int
+
+    def center(self) -> Tuple[int, int]:
+        return (self.x + self.w // 2, self.y + self.h // 2)
+
+    def intersects(self, other: "Rect", padding: int = 1) -> bool:
+        return not (
+            self.x + self.w + padding <= other.x
+            or other.x + other.w + padding <= self.x
+            or self.y + self.h + padding <= other.y
+            or other.y + other.h + padding <= self.y
+        )
+
+
+class RoomsGenerator:
+    """Rooms + corridors generator (BSP-like), robust and navigable.
+
+    This algorithm attempts to place a number of non-overlapping rectangular rooms
+    and connects them with L-shaped corridors in order of their centers.
+    """
+
+    def __init__(
+        self,
+        max_rooms: int = 18,
+        room_min_size: int = 4,
+        room_max_size: int = 10,
+    ) -> None:
+        self.max_rooms = max_rooms
+        self.room_min_size = room_min_size
+        self.room_max_size = room_max_size
+
+    def generate(self, width: int, height: int, seed: Optional[int] = None) -> MapGrid:
+        rng = random.Random(seed)
+        tiles = [[Tile.WALL for _ in range(width)] for _ in range(height)]
+
+        rooms: List[Rect] = []
+        attempts = 0
+        max_attempts = self.max_rooms * 10
+        while len(rooms) < self.max_rooms and attempts < max_attempts:
+            w = rng.randint(self.room_min_size, self.room_max_size)
+            h = rng.randint(self.room_min_size, self.room_max_size)
+            x = rng.randint(1, max(1, width - w - 2))
+            y = rng.randint(1, max(1, height - h - 2))
+            new_room = Rect(x, y, w, h)
+            if any(new_room.intersects(other, padding=1) for other in rooms):
+                attempts += 1
+                continue
+            self._carve_room(tiles, new_room)
+            rooms.append(new_room)
+            attempts += 1
+
+        if not rooms:
+            # Ensure at least one open area
+            center_room = Rect(width // 4, height // 4, width // 2, height // 2)
+            self._carve_room(tiles, center_room)
+            rooms.append(center_room)
+
+        # Sort by center for a simple connection scheme
+        rooms.sort(key=lambda r: (r.center()[0], r.center()[1]))
+        for i in range(1, len(rooms)):
+            x1, y1 = rooms[i - 1].center()
+            x2, y2 = rooms[i].center()
+            if rng.random() < 0.5:
+                self._carve_h_corridor(tiles, x1, x2, y1)
+                self._carve_v_corridor(tiles, y1, y2, x2)
+            else:
+                self._carve_v_corridor(tiles, y1, y2, x1)
+                self._carve_h_corridor(tiles, x1, x2, y2)
+
+        # Entrance at first room center, exit at farthest room center
+        entrance = rooms[0].center()
+        exit_pos = max((r.center() for r in rooms), key=lambda c: (c[0] - entrance[0]) ** 2 + (c[1] - entrance[1]) ** 2)
+
+        # Ensure bounds are walls
+        self._frame_walls(tiles)
+
+        logger.debug("RoomsGenerator: generated %d rooms", len(rooms))
+        return MapGrid(width, height, tiles, entrance, exit_pos)
+
+    @staticmethod
+    def _carve_room(tiles: List[List[Tile]], room: Rect) -> None:
+        for y in range(room.y, room.y + room.h):
+            for x in range(room.x, room.x + room.w):
+                tiles[y][x] = Tile.FLOOR
+
+    @staticmethod
+    def _carve_h_corridor(tiles: List[List[Tile]], x1: int, x2: int, y: int) -> None:
+        if x2 < x1:
+            x1, x2 = x2, x1
+        for x in range(x1, x2 + 1):
+            tiles[y][x] = Tile.FLOOR
+
+    @staticmethod
+    def _carve_v_corridor(tiles: List[List[Tile]], y1: int, y2: int, x: int) -> None:
+        if y2 < y1:
+            y1, y2 = y2, y1
+        for y in range(y1, y2 + 1):
+            tiles[y][x] = Tile.FLOOR
+
+    @staticmethod
+    def _frame_walls(tiles: List[List[Tile]]) -> None:
+        h = len(tiles)
+        w = len(tiles[0]) if h else 0
+        for x in range(w):
+            tiles[0][x] = Tile.WALL
+            tiles[h - 1][x] = Tile.WALL
+        for y in range(h):
+            tiles[y][0] = Tile.WALL
+            tiles[y][w - 1] = Tile.WALL

--- a/src/amor/dungeon/generator/cellular.py
+++ b/src/amor/dungeon/generator/cellular.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+import logging
+import random
+from typing import Optional, Tuple
+
+from ..tiles import MapGrid, Tile
+from ..pathfinding import largest_connected_region
+
+logger = logging.getLogger(__name__)
+
+
+class CellularGenerator:
+    """Cellular automata caverns generator.
+
+    Algorithm:
+    - Initialize grid with random walls based on initial probability.
+    - Apply a number of smoothing steps using the 8-neighbor rule (>= threshold => wall).
+    - Keep only the largest connected floor region (others become walls) to guarantee navigability.
+    - Pick entrance and exit as far apart floor tiles as feasible.
+    """
+
+    def __init__(
+        self,
+        initial_wall_prob: float = 0.45,
+        smooth_steps: int = 5,
+        wall_threshold: int = 5,
+        min_floor_fraction: float = 0.28,
+    ) -> None:
+        self.initial_wall_prob = float(initial_wall_prob)
+        self.smooth_steps = int(smooth_steps)
+        self.wall_threshold = int(wall_threshold)
+        self.min_floor_fraction = float(min_floor_fraction)
+
+    def generate(self, width: int, height: int, seed: Optional[int] = None) -> MapGrid:
+        rng = random.Random(seed)
+
+        tiles = [[Tile.WALL for _ in range(width)] for _ in range(height)]
+
+        def randomize():
+            for y in range(height):
+                for x in range(width):
+                    if x == 0 or y == 0 or x == width - 1 or y == height - 1:
+                        tiles[y][x] = Tile.WALL
+                    else:
+                        tiles[y][x] = Tile.WALL if rng.random() < self.initial_wall_prob else Tile.FLOOR
+
+        def smooth():
+            # Apply smoothing based on Moore neighborhood
+            for _ in range(self.smooth_steps):
+                new_tiles = [row[:] for row in tiles]
+                for y in range(1, height - 1):
+                    for x in range(1, width - 1):
+                        wall_count = 0
+                        for ny in (y - 1, y, y + 1):
+                            for nx in (x - 1, x, x + 1):
+                                if nx == x and ny == y:
+                                    continue
+                                if tiles[ny][nx] == Tile.WALL:
+                                    wall_count += 1
+                        new_tiles[y][x] = Tile.WALL if wall_count >= self.wall_threshold else Tile.FLOOR
+                # keep borders walls
+                for bx in range(width):
+                    new_tiles[0][bx] = Tile.WALL
+                    new_tiles[height - 1][bx] = Tile.WALL
+                for by in range(height):
+                    new_tiles[by][0] = Tile.WALL
+                    new_tiles[by][width - 1] = Tile.WALL
+                for y in range(height):
+                    tiles[y] = new_tiles[y]
+
+        # Try up to a few rerolls to satisfy min floor fraction
+        for attempt in range(5):
+            randomize()
+            smooth()
+            grid = MapGrid(width, height, tiles, (1, 1), (width - 2, height - 2))
+            largest = largest_connected_region(grid)
+            floor_cnt = len(largest)
+            frac = floor_cnt / float(width * height)
+            if frac >= self.min_floor_fraction:
+                break
+            if attempt == 4:
+                logger.warning(
+                    "CellularGenerator: min floor fraction not reached (%.2f < %.2f), proceeding",
+                    frac,
+                    self.min_floor_fraction,
+                )
+
+        # Keep only largest connected region as floors, rest walls
+        largest = largest_connected_region(grid)
+        for y in range(height):
+            for x in range(width):
+                grid.tiles[y][x] = Tile.FLOOR if (x, y) in largest else Tile.WALL
+
+        # Choose entrance/exit as far apart points in the region
+        entrance, exit_pos = self._pick_farthest_points(grid, rng)
+        grid.entrance = entrance
+        grid.exit = exit_pos
+
+        return grid
+
+    @staticmethod
+    def _pick_farthest_points(grid: MapGrid, rng: random.Random) -> Tuple[tuple[int, int], tuple[int, int]]:
+        # Collect floor positions
+        floors = [(x, y) for y in range(grid.height) for x in range(grid.width) if grid.tiles[y][x] == Tile.FLOOR]
+        if not floors:
+            # Fallback to center if something went wrong
+            c = (grid.width // 2, grid.height // 2)
+            return c, c
+        start = rng.choice(floors)
+        # BFS to find farthest from start
+        from collections import deque
+
+        def bfs_far(p: tuple[int, int]) -> tuple[tuple[int, int], int]:
+            q = deque([p])
+            dist = {p: 0}
+            far = (p, 0)
+            while q:
+                x, y = q.popleft()
+                d = dist[(x, y)]
+                if d > far[1]:
+                    far = ((x, y), d)
+                for nx, ny in grid.neighbors4(x, y):
+                    if (nx, ny) not in dist and grid.is_floor(nx, ny):
+                        dist[(nx, ny)] = d + 1
+                        q.append((nx, ny))
+            return far
+
+        a, _ = bfs_far(start)
+        b, _ = bfs_far(a)
+        return a, b

--- a/src/amor/dungeon/pathfinding.py
+++ b/src/amor/dungeon/pathfinding.py
@@ -1,0 +1,50 @@
+from collections import deque
+from typing import Optional, Tuple
+
+from .tiles import MapGrid, Tile
+
+
+def find_path_bfs(grid: MapGrid, start: Tuple[int, int], goal: Tuple[int, int]) -> Optional[int]:
+    """Breadth-first search shortest path length on FLOORS; returns number of steps or None.
+
+    Uses 4-directional movement.
+    """
+    if not grid.is_floor(*start) or not grid.is_floor(*goal):
+        return None
+
+    sx, sy = start
+    gx, gy = goal
+    q = deque([(sx, sy, 0)])
+    seen = {start}
+    while q:
+        x, y, d = q.popleft()
+        if (x, y) == (gx, gy):
+            return d
+        for nx, ny in grid.neighbors4(x, y):
+            if (nx, ny) not in seen and grid.tiles[ny][nx] == Tile.FLOOR:
+                seen.add((nx, ny))
+                q.append((nx, ny, d + 1))
+    return None
+
+
+def largest_connected_region(grid: MapGrid) -> set[tuple[int, int]]:
+    """Return set of coordinates belonging to the largest connected floor region (4-neigh)."""
+    visited: set[tuple[int, int]] = set()
+    best: set[tuple[int, int]] = set()
+    for y in range(grid.height):
+        for x in range(grid.width):
+            if grid.tiles[y][x] != Tile.FLOOR or (x, y) in visited:
+                continue
+            comp = set()
+            q = deque([(x, y)])
+            visited.add((x, y))
+            while q:
+                cx, cy = q.popleft()
+                comp.add((cx, cy))
+                for nx, ny in grid.neighbors4(cx, cy):
+                    if (nx, ny) not in visited and grid.tiles[ny][nx] == Tile.FLOOR:
+                        visited.add((nx, ny))
+                        q.append((nx, ny))
+            if len(comp) > len(best):
+                best = comp
+    return best

--- a/src/amor/dungeon/tiles.py
+++ b/src/amor/dungeon/tiles.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import List, Tuple
+
+
+class Tile(IntEnum):
+    WALL = 0
+    FLOOR = 1
+
+
+@dataclass
+class MapGrid:
+    """A simple tile grid with entrance/exit coordinates and helpers.
+
+    Coordinates are (x, y) with (0,0) at top-left; x grows to the right, y grows down.
+    """
+
+    width: int
+    height: int
+    tiles: List[List[Tile]]  # tiles[y][x]
+    entrance: Tuple[int, int]
+    exit: Tuple[int, int]
+
+    def in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def is_floor(self, x: int, y: int) -> bool:
+        return self.tiles[y][x] == Tile.FLOOR
+
+    def neighbors4(self, x: int, y: int):
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if self.in_bounds(nx, ny):
+                yield nx, ny
+
+    def copy(self) -> "MapGrid":
+        return MapGrid(
+            self.width,
+            self.height,
+            [row[:] for row in self.tiles],
+            self.entrance,
+            self.exit,
+        )

--- a/tests/test_dungeon_generation.py
+++ b/tests/test_dungeon_generation.py
@@ -1,0 +1,69 @@
+import os
+
+from amor.config import GenerationSettings
+from amor.dungeon.factory import DungeonFactory
+from amor.dungeon.pathfinding import find_path_bfs
+from amor.dungeon.tiles import Tile
+
+
+def assert_navigable(grid):
+    # Entrance and exit must be floors
+    ex, ey = grid.entrance
+    tx, ty = grid.exit
+    assert grid.is_floor(ex, ey)
+    assert grid.is_floor(tx, ty)
+
+    # Path between entrance and exit
+    dist = find_path_bfs(grid, grid.entrance, grid.exit)
+    assert dist is not None and dist > 0
+
+    # No out-of-bounds floors and borders are walls
+    for x in range(grid.width):
+        assert grid.tiles[0][x] == Tile.WALL
+        assert grid.tiles[grid.height - 1][x] == Tile.WALL
+    for y in range(grid.height):
+        assert grid.tiles[y][0] == Tile.WALL
+        assert grid.tiles[y][grid.width - 1] == Tile.WALL
+
+    # There should be a reasonable amount of floor
+    floors = sum(1 for y in range(grid.height) for x in range(grid.width) if grid.tiles[y][x] == Tile.FLOOR)
+    frac = floors / float(grid.width * grid.height)
+    assert 0.15 <= frac <= 0.8
+
+
+def test_bsp_rooms_navigable():
+    settings = GenerationSettings(algorithm="bsp", width=60, height=40, seed=123, max_rooms=15)
+    grid = DungeonFactory.generate(settings)
+    assert_navigable(grid)
+
+
+def test_cellular_cavern_navigable():
+    settings = GenerationSettings(
+        algorithm="cellular",
+        width=60,
+        height=40,
+        seed=123,
+        cell_initial_wall_prob=0.45,
+        cell_smooth_steps=5,
+        cell_wall_threshold=5,
+        cell_min_floor_fraction=0.25,
+    )
+    grid = DungeonFactory.generate(settings)
+    assert_navigable(grid)
+
+
+def test_env_switch_algorithm(monkeypatch):
+    # Verify environment-based selection works and doesn't crash
+    monkeypatch.setenv("AMOR_DUNGEON_ALGO", "cellular")
+    monkeypatch.setenv("AMOR_WIDTH", "50")
+    monkeypatch.setenv("AMOR_HEIGHT", "35")
+    monkeypatch.setenv("AMOR_SEED", "42")
+    settings = GenerationSettings.from_env()
+    grid = DungeonFactory.generate(settings)
+    assert_navigable(grid)
+
+    # Switch back to bsp
+    monkeypatch.setenv("AMOR_DUNGEON_ALGO", "bsp")
+    settings = GenerationSettings.from_env()
+    grid = DungeonFactory.generate(settings)
+    assert_navigable(grid)


### PR DESCRIPTION
Automated implementation for issue #35:

Summary of implementation:
- Added a modular dungeon generation subsystem under src/amor/dungeon with a clean interface and two algorithms: RoomsGenerator (rooms + corridors) and CellularGenerator (cellular automata caverns). Both implement DungeonGenerator.
- Implemented configuration via GenerationSettings (src/amor/config.py) with environment variable loading. AMOR_DUNGEON_ALGO selects the algorithm ("bsp" or "cellular"). Other parameters are tunable (map size, room sizes, cellular probabilities/steps).
- Created a DungeonFactory to choose the algorithm from settings and generate a MapGrid. The factory logs which algorithm is used and provides an easy integration point for the rest of the application.
- Implemented MapGrid and Tile primitives and a BFS pathfinder to validate navigability.
- Cellular caverns: start with random fill, apply smoothing, then keep only the largest connected region to guarantee navigability. Entrance/exit are chosen as far apart as possible within that region.
- Rooms generator: places non-overlapping rooms, connects them with L-shaped corridors, and ensures boundaries are walls. Entrance placed at first room center and exit at farthest room center.
- Tests: Added tests ensuring both algorithms produce navigable floors (entrance/exit are floors, BFS path exists, borders are walls, reasonable floor fraction). Also added a test that verifies environment-based algorithm selection.

Architecture decisions:
- Separation of concerns: configuration, tiles/grid, pathfinding, algorithm implementations, and factory kept in distinct modules for maintainability.
- Determinism: generators accept an optional seed; tests pass seeds to ensure repeatability.
- Robustness: cellular generator rerolls initialization a few times to meet a minimal open space fraction; it always enforces giant component connectivity. Rooms generator falls back to a single large room if placement fails.
- Logging hooks provided for observability.

Integration points:
- The rest of the game can call DungeonFactory.generate(GenerationSettings.from_env()) to obtain a MapGrid for the current floor.
- The MapGrid struct can be easily translated into a renderable tile layer for Arcade and used by the existing navigation/combat systems.

How to switch algorithms:
- Programmatically: GenerationSettings(algorithm="bsp") or GenerationSettings(algorithm="cellular").
- Via environment: export AMOR_DUNGEON_ALGO=cellular (or bsp) before running.

Both algorithms satisfy the acceptance criterion by producing navigable floors with a path between entrance and exit.


Files created:
- src/amor/__init__.py
- src/amor/config.py
- src/amor/dungeon/__init__.py
- src/amor/dungeon/tiles.py
- src/amor/dungeon/pathfinding.py
- src/amor/dungeon/generator/__init__.py
- src/amor/dungeon/generator/base.py
- src/amor/dungeon/generator/bsp_rooms.py
- src/amor/dungeon/generator/cellular.py
- src/amor/dungeon/factory.py
- tests/test_dungeon_generation.py