### PR TITLE
Build App: Item schema & equip/consume behaviors

### DIFF
--- a/data/schemas/item.schema.json
+++ b/data/schemas/item.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://amor-mortuorum.dev/schemas/item.schema.json",
+  "title": "Amor Mortuorum Item",
+  "description": "Schema for game items (equipment, consumables, keys)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "type"],
+  "properties": {
+    "id": {"type": "string", "minLength": 1},
+    "name": {"type": "string", "minLength": 1},
+    "type": {"type": "string", "enum": ["equipment", "consumable", "key"]},
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": []
+    },
+    "slot": {"type": "string", "enum": ["weapon", "armor", "accessory"]},
+    "stat_deltas": {
+      "type": "object",
+      "description": "Additive stat modifiers applied when equipped",
+      "additionalProperties": false,
+      "properties": {
+        "max_hp": {"type": "integer"},
+        "max_mp": {"type": "integer"},
+        "atk": {"type": "integer"},
+        "defense": {"type": "integer"},
+        "magic": {"type": "integer"},
+        "resistance": {"type": "integer"},
+        "speed": {"type": "integer"},
+        "luck": {"type": "integer"}
+      },
+      "default": {}
+    },
+    "effects": {
+      "type": "array",
+      "description": "List of effects applied on consume",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {"type": "string", "enum": ["heal_hp", "heal_mp"]},
+          "amount": {
+            "description": "Numeric amount or composite amount descriptor",
+            "oneOf": [
+              {"type": ["integer", "number"]},
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "flat": {"type": ["integer", "number"]},
+                  "percent_max": {"type": ["number"]},
+                  "percent_missing": {"type": ["number"]}
+                }
+              }
+            ]
+          },
+          "target": {"type": "string", "enum": ["self"], "default": "self"}
+        }
+      },
+      "default": []
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"type": {"const": "equipment"}}},
+      "then": {
+        "required": ["slot"],
+        "properties": {
+          "effects": false
+        }
+      }
+    },
+    {
+      "if": {"properties": {"type": {"const": "consumable"}}},
+      "then": {
+        "required": ["effects"],
+        "properties": {
+          "slot": false,
+          "stat_deltas": false
+        }
+      }
+    }
+  ]
+}

--- a/src/amor_mortuorum/__init__.py
+++ b/src/amor_mortuorum/__init__.py
@@ -1,0 +1,10 @@
+'''
+Amor Mortuorum core package.
+
+This package contains the game domain: characters, items, inventory, and systems.
+'''
+__all__ = [
+    'items',
+    'inventory',
+    'characters',
+]

--- a/src/amor_mortuorum/characters/__init__.py
+++ b/src/amor_mortuorum/characters/__init__.py
@@ -1,0 +1,6 @@
+'''
+Characters package: player and enemy stats and behaviors.
+'''
+from .stats import Stats
+
+__all__ = ['Stats']

--- a/src/amor_mortuorum/characters/stats.py
+++ b/src/amor_mortuorum/characters/stats.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Stats:
+    """
+    Character stats model with base values and additive equipment modifiers.
+
+    - base_*: intrinsic/base values (no equipment)
+    - mod_*: additive modifiers from equipment
+    - hp/mp: current resource values
+    """
+
+    base_max_hp: int = 100
+    base_max_mp: int = 20
+    base_atk: int = 5
+    base_defense: int = 5
+    base_magic: int = 5
+    base_resistance: int = 5
+    base_speed: int = 5
+    base_luck: int = 5
+
+    mod_max_hp: int = 0
+    mod_max_mp: int = 0
+    mod_atk: int = 0
+    mod_defense: int = 0
+    mod_magic: int = 0
+    mod_resistance: int = 0
+    mod_speed: int = 0
+    mod_luck: int = 0
+
+    hp: int = field(default=0)
+    mp: int = field(default=0)
+
+    def __post_init__(self) -> None:
+        # Initialize current values if not set
+        if self.hp <= 0:
+            self.hp = self.max_hp
+        if self.mp <= 0:
+            self.mp = self.max_mp
+
+    # Effective properties
+    @property
+    def max_hp(self) -> int:
+        return max(1, self.base_max_hp + self.mod_max_hp)
+
+    @property
+    def max_mp(self) -> int:
+        return max(0, self.base_max_mp + self.mod_max_mp)
+
+    @property
+    def atk(self) -> int:
+        return self.base_atk + self.mod_atk
+
+    @property
+    def defense(self) -> int:
+        return self.base_defense + self.mod_defense
+
+    @property
+    def magic(self) -> int:
+        return self.base_magic + self.mod_magic
+
+    @property
+    def resistance(self) -> int:
+        return self.base_resistance + self.mod_resistance
+
+    @property
+    def speed(self) -> int:
+        return self.base_speed + self.mod_speed
+
+    @property
+    def luck(self) -> int:
+        return self.base_luck + self.mod_luck
+
+    def _apply_delta(self, key: str, delta: int) -> None:
+        if key not in {
+            'max_hp', 'max_mp', 'atk', 'defense', 'magic', 'resistance', 'speed', 'luck'
+        }:
+            logger.debug('Ignoring unsupported stat key: %s', key)
+            return
+        attr_name = f'mod_{key}' if key in {'max_hp', 'max_mp'} else f'mod_{key}'
+        before = getattr(self, attr_name)
+        setattr(self, attr_name, before + int(delta))
+        logger.debug('Applied delta %s: %d -> %d', attr_name, before, getattr(self, attr_name))
+        # Clamp current HP/MP to new maxima
+        self._clamp_resources()
+
+    def apply_stat_deltas(self, deltas: Dict[str, int]) -> None:
+        """Apply a set of additive stat deltas (e.g., from equipment)."""
+        for k, v in deltas.items():
+            self._apply_delta(k, int(v))
+
+    def remove_stat_deltas(self, deltas: Dict[str, int]) -> None:
+        """Remove a set of additive stat deltas (inverse of apply)."""
+        for k, v in deltas.items():
+            self._apply_delta(k, -int(v))
+
+    def _clamp_resources(self) -> None:
+        old_hp, old_mp = self.hp, self.mp
+        self.hp = max(0, min(self.hp, self.max_hp))
+        self.mp = max(0, min(self.mp, self.max_mp))
+        if (old_hp, old_mp) != (self.hp, self.mp):
+            logger.debug('Clamped resources: HP %d->%d MP %d->%d', old_hp, self.hp, old_mp, self.mp)
+
+    def effective_stats(self) -> Dict[str, int]:
+        return {
+            'max_hp': self.max_hp,
+            'max_mp': self.max_mp,
+            'atk': self.atk,
+            'defense': self.defense,
+            'magic': self.magic,
+            'resistance': self.resistance,
+            'speed': self.speed,
+            'luck': self.luck,
+        }

--- a/src/amor_mortuorum/inventory/__init__.py
+++ b/src/amor_mortuorum/inventory/__init__.py
@@ -1,0 +1,6 @@
+'''
+Inventory package: manage items, equipment, and consumption.
+'''
+from .inventory import Inventory
+
+__all__ = ['Inventory']

--- a/src/amor_mortuorum/inventory/inventory.py
+++ b/src/amor_mortuorum/inventory/inventory.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from ..characters.stats import Stats
+from ..items.models import EquipmentSlot, Item, ItemType, apply_consumable_effects
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InventoryEntry:
+    item: Item
+    qty: int
+
+
+class Inventory:
+    """
+    Inventory with item quantities and equipped items per slot.
+
+    - Equipment: equipping applies stat deltas to the provided Stats instance.
+    - Consumables: consuming applies effects and reduces quantity (removing item at zero).
+
+    Note: Equipping does not consume inventory quantity; it only changes the equipped mapping.
+    """
+
+    def __init__(self) -> None:
+        self._items: Dict[str, InventoryEntry] = {}
+        self._equipped: Dict[EquipmentSlot, Optional[str]] = {
+            EquipmentSlot.WEAPON: None,
+            EquipmentSlot.ARMOR: None,
+            EquipmentSlot.ACCESSORY: None,
+        }
+
+    def add_item(self, item: Item, qty: int = 1) -> None:
+        if qty <= 0:
+            return
+        entry = self._items.get(item.id)
+        if entry:
+            entry.qty += qty
+        else:
+            self._items[item.id] = InventoryEntry(item=item, qty=qty)
+        logger.debug('Added %d x %s (total=%d)', qty, item.id, self._items[item.id].qty)
+
+    def get_quantity(self, item_id: str) -> int:
+        entry = self._items.get(item_id)
+        return entry.qty if entry else 0
+
+    def get_item(self, item_id: str) -> Optional[Item]:
+        entry = self._items.get(item_id)
+        return entry.item if entry else None
+
+    def equipped(self) -> Dict[EquipmentSlot, Optional[str]]:
+        return dict(self._equipped)
+
+    def equip(self, stats: Stats, item_id: str) -> Optional[str]:
+        """
+        Equip the given item, applying its stat deltas.
+
+        Returns the previously equipped item id in that slot (if any).
+        Raises ValueError for invalid operations.
+        """
+        entry = self._items.get(item_id)
+        if not entry:
+            raise ValueError(f'Item not in inventory: {item_id}')
+        item = entry.item
+        if item.type != ItemType.EQUIPMENT:
+            raise ValueError(f'Cannot equip non-equipment item: {item_id}')
+        slot = item.slot
+        assert slot is not None
+
+        # Unequip previous in slot if present
+        previous_id = self._equipped.get(slot)
+        if previous_id:
+            prev_item = self._items[previous_id].item
+            stats.remove_stat_deltas(prev_item.stat_deltas)
+            logger.debug('Unequipped %s from %s', previous_id, slot)
+
+        # Equip new
+        self._equipped[slot] = item_id
+        stats.apply_stat_deltas(item.stat_deltas)
+        logger.debug('Equipped %s to %s; applied deltas %s', item_id, slot, item.stat_deltas)
+        return previous_id
+
+    def unequip(self, stats: Stats, slot: EquipmentSlot) -> Optional[str]:
+        """
+        Unequip currently equipped item from the slot and remove its stat deltas.
+
+        Returns the unequipped item id if any.
+        """
+        item_id = self._equipped.get(slot)
+        if not item_id:
+            return None
+        prev_item = self._items[item_id].item
+        stats.remove_stat_deltas(prev_item.stat_deltas)
+        self._equipped[slot] = None
+        logger.debug('Unequipped %s from %s; removed deltas %s', item_id, slot, prev_item.stat_deltas)
+        return item_id
+
+    def consume(self, stats: Stats, item_id: str) -> Dict[str, int]:
+        """
+        Consume one quantity of a consumable item, applying its effects to stats.
+
+        Returns a summary of applied effects. Removes the item from inventory when qty reaches zero.
+        Raises ValueError for invalid operations.
+        """
+        entry = self._items.get(item_id)
+        if not entry:
+            raise ValueError(f'Item not in inventory: {item_id}')
+        if entry.item.type != ItemType.CONSUMABLE:
+            raise ValueError(f'Cannot consume non-consumable item: {item_id}')
+        # Apply effects
+        summary = apply_consumable_effects(stats, entry.item.effects)
+        # Reduce quantity
+        entry.qty -= 1
+        if entry.qty <= 0:
+            del self._items[item_id]
+            logger.debug('Consumed last %s; removed from inventory', item_id)
+        else:
+            logger.debug('Consumed %s; remaining=%d', item_id, entry.qty)
+        return summary

--- a/src/amor_mortuorum/items/__init__.py
+++ b/src/amor_mortuorum/items/__init__.py
@@ -1,0 +1,12 @@
+'''
+Items package: item models, schema validation, and effects.
+'''
+from .models import Item, ItemType, EquipmentSlot
+from .schema import validate_item_dict
+
+__all__ = [
+    'Item',
+    'ItemType',
+    'EquipmentSlot',
+    'validate_item_dict',
+]

--- a/src/amor_mortuorum/items/models.py
+++ b/src/amor_mortuorum/items/models.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from .schema import validate_item_dict
+
+logger = logging.getLogger(__name__)
+
+
+class ItemType(str, Enum):
+    EQUIPMENT = 'equipment'
+    CONSUMABLE = 'consumable'
+    KEY = 'key'
+
+
+class EquipmentSlot(str, Enum):
+    WEAPON = 'weapon'
+    ARMOR = 'armor'
+    ACCESSORY = 'accessory'
+
+
+# Supported stat keys for equipment deltas
+SUPPORTED_STATS = {
+    'max_hp', 'max_mp', 'atk', 'defense', 'magic', 'resistance', 'speed', 'luck'
+}
+
+
+@dataclass
+class Item:
+    """Domain model for a game item.
+
+    This model is intentionally light-weight and validates against the JSON schema
+    when constructed from raw dictionaries.
+    """
+
+    id: str
+    name: str
+    type: ItemType
+    # Equipment-specific
+    slot: Optional[EquipmentSlot] = None
+    stat_deltas: Dict[str, int] = field(default_factory=dict)
+    # Consumable-specific
+    effects: List[Dict[str, Any]] = field(default_factory=list)
+    # Tags / metadata
+    tags: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'Item':
+        """Create an Item from a dict, validating with the JSON schema."""
+        validate_item_dict(data)
+        item_type = ItemType(data['type'])
+        slot = None
+        stat_deltas: Dict[str, int] = {}
+        effects: List[Dict[str, Any]] = []
+        if item_type == ItemType.EQUIPMENT:
+            slot = EquipmentSlot(data['slot'])
+            stat_deltas = {k: int(v) for k, v in data.get('stat_deltas', {}).items()}
+        elif item_type == ItemType.CONSUMABLE:
+            effects = list(data.get('effects', []))
+        return cls(
+            id=data['id'],
+            name=data['name'],
+            type=item_type,
+            slot=slot,
+            stat_deltas=stat_deltas,
+            effects=effects,
+            tags=list(data.get('tags', [])),
+        )
+
+    def is_equipment(self) -> bool:
+        return self.type == ItemType.EQUIPMENT
+
+    def is_consumable(self) -> bool:
+        return self.type == ItemType.CONSUMABLE
+
+
+# Effects processing for consumables
+
+def _compute_amount(spec: Any, max_value: int, current_value: int) -> int:
+    """
+    Compute an integer amount from a spec that can be:
+    - int/float: direct amount
+    - dict: {'flat': int, 'percent_max': float, 'percent_missing': float}
+    Values are summed, with percent components multiplied accordingly.
+    """
+    if spec is None:
+        return 0
+    if isinstance(spec, (int, float)):
+        return int(round(spec))
+    if isinstance(spec, dict):
+        flat = spec.get('flat', 0)
+        pct_max = spec.get('percent_max', 0.0)
+        pct_missing = spec.get('percent_missing', 0.0)
+        missing = max(0, max_value - current_value)
+        amount = float(flat) + float(pct_max) * max_value + float(pct_missing) * missing
+        return int(round(amount))
+    raise ValueError(f'Unsupported amount spec: {spec!r}')
+
+
+def apply_consumable_effects(stats: 'Stats', effects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Apply a list of consumable effects to the provided stats object.
+
+    Currently supported effects:
+    - {'type': 'heal_hp', 'amount': int|dict}
+    - {'type': 'heal_mp', 'amount': int|dict}
+
+    Returns a summary dict with keys per effect type, values representing net change applied.
+    """
+    summary: Dict[str, Any] = {}
+    for eff in effects:
+        eff_type = eff.get('type')
+        if eff_type == 'heal_hp':
+            amount = _compute_amount(eff.get('amount', 0), stats.max_hp, stats.hp)
+            before = stats.hp
+            stats.hp = min(stats.max_hp, max(0, stats.hp + amount))
+            delta = stats.hp - before
+            summary['heal_hp'] = summary.get('heal_hp', 0) + delta
+            logger.debug('Applied heal_hp %s => +%d (HP %d -> %d)', eff.get('amount'), delta, before, stats.hp)
+        elif eff_type == 'heal_mp':
+            amount = _compute_amount(eff.get('amount', 0), stats.max_mp, stats.mp)
+            before = stats.mp
+            stats.mp = min(stats.max_mp, max(0, stats.mp + amount))
+            delta = stats.mp - before
+            summary['heal_mp'] = summary.get('heal_mp', 0) + delta
+            logger.debug('Applied heal_mp %s => +%d (MP %d -> %d)', eff.get('amount'), delta, before, stats.mp)
+        else:
+            logger.warning('Unsupported consumable effect type: %s', eff_type)
+    return summary
+
+
+# Avoid circular imports in type hints
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ..characters.stats import Stats
+
+__all__ = [
+    'Item',
+    'ItemType',
+    'EquipmentSlot',
+    'apply_consumable_effects',
+]

--- a/src/amor_mortuorum/items/schema.py
+++ b/src/amor_mortuorum/items/schema.py
@@ -1,0 +1,53 @@
+import json
+import logging
+import os
+from functools import lru_cache
+from typing import Any, Dict
+
+from jsonschema import Draft202012Validator
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _load_item_schema() -> Dict[str, Any]:
+    """
+    Load the item JSON schema from the data/schemas directory.
+
+    The function is cached for performance since the schema is static.
+    """
+    # Search for the schema relative to project root, falling back to package-relative path
+    potential_paths = [
+        os.path.join(os.getcwd(), 'data', 'schemas', 'item.schema.json'),
+        os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'schemas', 'item.schema.json'),
+    ]
+    for path in potential_paths:
+        normalized = os.path.abspath(path)
+        if os.path.exists(normalized):
+            with open(normalized, 'r', encoding='utf-8') as f:
+                logger.debug('Loading item schema from %s', normalized)
+                return json.load(f)
+    # If not found, raise a clear error
+    raise FileNotFoundError('Item schema file not found. Expected at data/schemas/item.schema.json')
+
+
+def validate_item_dict(data: Dict[str, Any]) -> None:
+    """
+    Validate a single item dictionary against the item JSON schema.
+
+    Raises:
+        jsonschema.ValidationError if the data is invalid.
+    """
+    schema = _load_item_schema()
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        # Log all errors, then raise the first to provide a clear exception
+        for err in errors:
+            logger.error('Item schema validation error at %s: %s', list(err.path), err.message)
+        raise errors[0]
+
+
+__all__ = [
+    'validate_item_dict',
+]

--- a/tests/test_items_equip_consume.py
+++ b/tests/test_items_equip_consume.py
@@ -1,0 +1,116 @@
+import pytest
+
+from amor_mortuorum.characters.stats import Stats
+from amor_mortuorum.inventory.inventory import Inventory
+from amor_mortuorum.items.models import EquipmentSlot, Item, ItemType
+
+
+def test_equip_applies_and_replaces_stat_deltas():
+    stats = Stats(
+        base_max_hp=100, base_max_mp=20, base_atk=10, base_defense=5,
+        base_magic=3, base_resistance=2, base_speed=4, base_luck=1
+    )
+
+    inv = Inventory()
+
+    sword_1 = Item.from_dict({
+        'id': 'iron_sword', 'name': 'Iron Sword', 'type': 'equipment',
+        'slot': 'weapon', 'stat_deltas': {'atk': 5}
+    })
+    sword_2 = Item.from_dict({
+        'id': 'steel_sword', 'name': 'Steel Sword', 'type': 'equipment',
+        'slot': 'weapon', 'stat_deltas': {'atk': 10}
+    })
+
+    inv.add_item(sword_1, 1)
+    inv.add_item(sword_2, 1)
+
+    # Equip iron sword
+    prev = inv.equip(stats, 'iron_sword')
+    assert prev is None
+    assert stats.atk == 15
+    assert inv.equipped()[EquipmentSlot.WEAPON] == 'iron_sword'
+
+    # Replace with steel sword
+    prev = inv.equip(stats, 'steel_sword')
+    assert prev == 'iron_sword'
+    assert stats.atk == 20  # 10 base + 10 steel
+    assert inv.equipped()[EquipmentSlot.WEAPON] == 'steel_sword'
+
+    # Unequip
+    removed = inv.unequip(stats, EquipmentSlot.WEAPON)
+    assert removed == 'steel_sword'
+    assert stats.atk == 10
+    assert inv.equipped()[EquipmentSlot.WEAPON] is None
+
+
+def test_consume_potion_heals_and_is_removed():
+    stats = Stats(base_max_hp=100, base_max_mp=20, base_atk=5, base_defense=5)
+    stats.hp = 40
+
+    inv = Inventory()
+
+    potion = Item.from_dict({
+        'id': 'potion_small', 'name': 'Small Potion', 'type': 'consumable',
+        'effects': [{ 'type': 'heal_hp', 'amount': 50 }]
+    })
+
+    inv.add_item(potion, 1)
+    summary = inv.consume(stats, 'potion_small')
+
+    assert summary['heal_hp'] == 50
+    assert stats.hp == 90
+    # Item should be removed from inventory
+    assert inv.get_quantity('potion_small') == 0
+
+
+def test_consume_scroll_mp_percent_and_quantity_decrements():
+    stats = Stats(base_max_hp=80, base_max_mp=50, base_atk=5, base_defense=5)
+    stats.mp = 10
+
+    inv = Inventory()
+
+    scroll = Item.from_dict({
+        'id': 'ether_scroll', 'name': 'Ether Scroll', 'type': 'consumable',
+        'effects': [{ 'type': 'heal_mp', 'amount': { 'percent_max': 0.5 } }]
+    })
+
+    inv.add_item(scroll, 2)
+
+    summary = inv.consume(stats, 'ether_scroll')
+    assert summary['heal_mp'] == 25  # 50% of 50
+    assert stats.mp == 35
+    assert inv.get_quantity('ether_scroll') == 1
+
+    # Consume again should clamp to max
+    summary = inv.consume(stats, 'ether_scroll')
+    # Expected heal is 15 (to reach 50)
+    assert summary['heal_mp'] == 15
+    assert stats.mp == 50
+    assert inv.get_quantity('ether_scroll') == 0
+
+
+def test_invalid_operations_raise():
+    stats = Stats()
+    inv = Inventory()
+
+    # Non-existent item
+    with pytest.raises(ValueError):
+        inv.equip(stats, 'nope')
+
+    # Wrong type for consume/equip
+    key_item = Item.from_dict({'id': 'key1', 'name': 'Crypt Key', 'type': 'key'})
+    inv.add_item(key_item, 1)
+    with pytest.raises(ValueError):
+        inv.consume(stats, 'key1')
+
+    armor = Item.from_dict({
+        'id': 'leather_armor', 'name': 'Leather Armor', 'type': 'equipment',
+        'slot': 'armor', 'stat_deltas': {'defense': 2}
+    })
+    inv.add_item(armor, 1)
+    # Equip armor (valid)
+    inv.equip(stats, 'leather_armor')
+    # Try to consume it
+    with pytest.raises(ValueError):
+        inv.consume(stats, 'leather_armor')


### PR DESCRIPTION
Automated implementation for issue #42:

Overview:
- Implemented a complete item system slice with JSON schema validation and runtime behavior for equipping and consuming items.
- Added a JSON Schema (data/schemas/item.schema.json) defining item structure for equipment and consumables, including stat deltas and consumable effect definitions.
- Created domain models for Items (src/amor_mortuorum/items/models.py) with from_dict schema validation, enums for ItemType and EquipmentSlot, and an effect application engine for consumables (heal HP/MP with flat or percentage-based amounts).
- Built a Stats model (src/amor_mortuorum/characters/stats.py) with base and modifier separation, effective computed stats, and clamping logic for HP/MP when maxima change. Equipment modifies additive modifiers; equipping and unequipping adjusts stats accordingly.
- Implemented an Inventory (src/amor_mortuorum/inventory/inventory.py) supporting item quantities, equipping to slots (weapon/armor/accessory), and consuming consumables by applying effects and removing the item when quantity reaches zero. Equipping does not consume quantities.
- Added package initializers and thorough logging for operations and validation errors.
- Comprehensive tests (tests/test_items_equip_consume.py) validating equip stat changes, replacement and unequip behavior, consumable heal effects with flat and percent amounts, inventory removal upon consumption, and error handling for invalid operations.

Design choices:
- Stat keys use snake_case, matching JSON schema and Stats properties; supported stats are max_hp, max_mp, atk, defense, magic, resistance, speed, luck.
- Equip effects are simple additive deltas to modifiers, keeping base stats immutable; current HP/MP are clamped when maxima change.
- Consumable effects are processed via a small effect engine accommodating flat and percentage specifications to allow future growth (e.g., buffs/status could be added later).
- JSON schema enforces mutually exclusive fields for equipment vs consumables and has future-proof defaults.

Integration points:
- Item definitions can be loaded from external JSON data files; Item.from_dict ensures they conform to schema at load time.
- Systems requiring item effects can call Inventory.consume with the Stats instance representing the current actor.

Testing:
- Tests use Item.from_dict with dicts that conform to the schema; they assert stat changes and inventory state transitions.

Notes:
- The current implementation focuses on immediate effects (healing). Extending to scrolls that apply combat skills can be added by introducing additional effect types handled by the same effect engine.


Files created:
- src/amor_mortuorum/__init__.py
- src/amor_mortuorum/items/__init__.py
- src/amor_mortuorum/items/schema.py
- src/amor_mortuorum/items/models.py
- src/amor_mortuorum/characters/__init__.py
- src/amor_mortuorum/characters/stats.py
- src/amor_mortuorum/inventory/__init__.py
- src/amor_mortuorum/inventory/inventory.py
- data/schemas/item.schema.json
- tests/test_items_equip_consume.py