### PR TITLE
Build App: Final boss (B99): The Oblivion Heart

### DIFF
--- a/data/bosses/oblivion_heart.json
+++ b/data/bosses/oblivion_heart.json
@@ -1,0 +1,35 @@
+{
+  "max_hp": 5000,
+  "thresholds": {
+    "phase1": 1.01,
+    "phase2": 0.7,
+    "phase3": 0.2
+  },
+  "music": {
+    "phase1": "music.oblivion_heart.phase1",
+    "phase2": "music.oblivion_heart.phase2",
+    "phase3": "music.oblivion_heart.enraged"
+  },
+  "sfx": {
+    "enter_p1": "sfx.boss.oblivion_heart.phase1",
+    "enter_p2": "sfx.boss.oblivion_heart.phase2",
+    "enter_p3": "sfx.boss.oblivion_heart.enrage",
+    "shadow_pulse": "sfx.boss.shadow_pulse",
+    "abyssal_maelstrom": "sfx.boss.abyssal_maelstrom",
+    "heartseeker_drain": "sfx.boss.heartseeker_drain",
+    "reconstitution": "sfx.boss.reconstitution",
+    "cataclysmic_beat": "sfx.boss.cataclysmic_beat",
+    "combo": "sfx.boss.combo",
+    "death": "sfx.boss.death"
+  },
+  "numbers": {
+    "p1_st": 120,
+    "p1_aoe": 65,
+    "p2_st": 160,
+    "p2_aoe": 95,
+    "p2_drain": 140,
+    "p3_st": 180,
+    "p3_drain": 180,
+    "p3_cataclysm": 220
+  }
+}

--- a/src/amor_mortuorum/bosses/base.py
+++ b/src/amor_mortuorum/bosses/base.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+from ..core.events import EventBus
+from ..core.save import SaveService
+from ..combat.actors import Party
+
+
+@dataclass
+class PhaseDefinition:
+    id: str
+    threshold_pct: float  # 0..1 inclusive. Phase becomes active at or below this boss HP fraction
+    music_track: str
+    enter_sfx: str
+
+
+class BossPhase:
+    """
+    Encapsulates per-phase AI hooks and audiovisual cues.
+    """
+
+    def __init__(
+        self,
+        definition: PhaseDefinition,
+        on_choose_action: Callable[["BaseBoss", Party], "Action"],
+        on_enter: Optional[Callable[["BaseBoss"], None]] = None,
+    ) -> None:
+        self.definition = definition
+        self.on_choose_action = on_choose_action
+        self.on_enter = on_enter
+
+
+class BaseBoss:
+    """Base boss entity with phases, AI and lifecycle hooks."""
+
+    def __init__(
+        self,
+        name: str,
+        max_hp: int,
+        bus: EventBus,
+        save: SaveService,
+        phases: List[BossPhase],
+        death_sfx: str = "sfx.boss.death",
+        relic_id: Optional[str] = None,
+        clear_flag: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.max_hp = max_hp
+        self.hp = max_hp
+        self._bus = bus
+        self._save = save
+        self._phases = phases
+        self._current_phase_index = 0
+        self._turn = 0
+        self._death_sfx = death_sfx
+        self._relic_id = relic_id
+        self._clear_flag = clear_flag
+        # Cooldowns accessible to AI hooks
+        self.cooldowns: Dict[str, int] = {}
+        # Status flags like 'enraged'
+        self.status: Dict[str, bool] = {}
+
+    @property
+    def phase(self) -> BossPhase:
+        return self._phases[self._current_phase_index]
+
+    def start_battle(self) -> None:
+        # Enter initial phase audiovisuals
+        self._enter_phase(0)
+
+    def _enter_phase(self, idx: int) -> None:
+        self._current_phase_index = idx
+        pdef = self._phases[idx].definition
+        # Broadcast music and SFX
+        self._bus.publish("music.change", {"track": pdef.music_track, "boss": self.name, "phase": pdef.id})
+        self._bus.publish("sfx.play", {"key": pdef.enter_sfx, "boss": self.name, "phase": pdef.id})
+        # Call custom on_enter if any
+        if self._phases[idx].on_enter:
+            self._phases[idx].on_enter(self)
+
+    def update_phase_if_needed(self) -> None:
+        hp_frac = self.hp / max(1, self.max_hp)
+        target_index = self._current_phase_index
+        for i, p in enumerate(self._phases):
+            if hp_frac <= p.definition.threshold_pct:
+                target_index = max(target_index, i)
+        if target_index != self._current_phase_index:
+            self._enter_phase(target_index)
+
+    def choose_action(self, party: Party) -> "Action":
+        return self.phase.on_choose_action(self, party)
+
+    def take_turn(self, party: Party) -> Dict:
+        self.update_phase_if_needed()
+        # Tick down cooldowns at start of boss turn
+        for k in list(self.cooldowns.keys()):
+            if self.cooldowns[k] > 0:
+                self.cooldowns[k] -= 1
+        act = self.choose_action(party)
+        self._turn += 1
+        return act.execute(self, party)
+
+    def receive_damage(self, amount: int) -> int:
+        before = self.hp
+        self.hp = max(0, self.hp - max(0, amount))
+        if self.hp == 0:
+            self.on_defeat()
+        else:
+            self.update_phase_if_needed()
+        return before - self.hp
+
+    def heal(self, amount: int) -> int:
+        before = self.hp
+        self.hp = min(self.max_hp, self.hp + max(0, amount))
+        return self.hp - before
+
+    def on_defeat(self) -> None:
+        # Play death SFX
+        self._bus.publish("sfx.play", {"key": self._death_sfx, "boss": self.name})
+        # Clear music
+        self._bus.publish("music.stop", {"boss": self.name})
+        # Record clear condition
+        if self._clear_flag:
+            self._save.set_flag(self._clear_flag, True)
+        if self._relic_id and not self._save.has_relic(self._relic_id):
+            self._save.award_relic(self._relic_id)
+
+
+# Late import to avoid circulars for type hints
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:  # pragma: no cover
+    from ..combat.actions import Action

--- a/src/amor_mortuorum/bosses/oblivion_heart.py
+++ b/src/amor_mortuorum/bosses/oblivion_heart.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+from .base import BaseBoss, BossPhase, PhaseDefinition
+from ..combat.actions import DamageAction, DrainAction, HealSelfPercent, MultiAction, Action
+from ..combat.actors import Party
+from ..core.events import EventBus
+from ..core.save import SaveService
+
+
+@dataclass
+class OHConfig:
+    max_hp: int
+    thresholds: Dict[str, float]
+    music: Dict[str, str]
+    sfx: Dict[str, str]
+    numbers: Dict[str, int]
+
+    @staticmethod
+    def from_json(path: str | Path) -> "OHConfig":
+        data = json.loads(Path(path).read_text())
+        return OHConfig(
+            max_hp=int(data["max_hp"]),
+            thresholds={k: float(v) for k, v in data["thresholds"].items()},
+            music=data["music"],
+            sfx=data["sfx"],
+            numbers={k: int(v) for k, v in data["numbers"].items()},
+        )
+
+
+def build_oblivion_heart(config: OHConfig, bus: EventBus, save: SaveService) -> BaseBoss:
+    name = "Oblivion Heart"
+
+    def p1_ai(self: BaseBoss, party: Party) -> Action:
+        # Phase 1: Primarily single-target; opportunistic AoE on cooldown
+        if self.cooldowns.get("p1_aoe", 0) == 0:
+            self.cooldowns["p1_aoe"] = 3
+            bus.publish("sfx.play", {"key": config.sfx["abyssal_maelstrom"], "boss": name})
+            return DamageAction("Abyssal Maelstrom", damage=config.numbers["p1_aoe"], target="all")
+        # Default single-target pulse
+        bus.publish("sfx.play", {"key": config.sfx["shadow_pulse"], "boss": name})
+        return DamageAction("Shadow Pulse", damage=config.numbers["p1_st"], target="single")
+
+    def p2_ai(self: BaseBoss, party: Party) -> Action:
+        # Phase 2: Mix of AoE and self-heal check below 40% HP
+        hp_frac = self.hp / self.max_hp
+        if hp_frac <= 0.4 and self.cooldowns.get("self_heal", 0) == 0:
+            self.cooldowns["self_heal"] = 4
+            bus.publish("sfx.play", {"key": config.sfx["reconstitution"], "boss": name})
+            return HealSelfPercent("Oblivion Reconstitution", percent=0.2)
+        if self.cooldowns.get("p2_aoe", 0) == 0:
+            self.cooldowns["p2_aoe"] = 2
+            bus.publish("sfx.play", {"key": config.sfx["abyssal_maelstrom"], "boss": name})
+            return DamageAction("Abyssal Maelstrom", damage=config.numbers["p2_aoe"], target="all")
+        # Opportunistic drain to self-heal slightly
+        if self.cooldowns.get("drain", 0) == 0:
+            self.cooldowns["drain"] = 2
+            bus.publish("sfx.play", {"key": config.sfx["heartseeker_drain"], "boss": name})
+            return DrainAction("Heartseeker Drain", damage=config.numbers["p2_drain"], heal_ratio=0.5)
+        bus.publish("sfx.play", {"key": config.sfx["shadow_pulse"], "boss": name})
+        return DamageAction("Shadow Pulse", damage=config.numbers["p2_st"], target="single")
+
+    def p3_enter(self: BaseBoss) -> None:
+        # Enrage status, immediate roar SFX handled by phase enter SFX.
+        self.status["enraged"] = True
+        # Make Cataclysm available immediately
+        self.cooldowns["cataclysm"] = 0
+
+    def p3_ai(self: BaseBoss, party: Party) -> Action:
+        # Phase 3: Enraged. Cataclysmic Beat on cooldown, otherwise drain + hit combo.
+        if self.cooldowns.get("cataclysm", 0) == 0:
+            self.cooldowns["cataclysm"] = 2
+            bus.publish("sfx.play", {"key": config.sfx["cataclysmic_beat"], "boss": name})
+            return DamageAction("Cataclysmic Beat", damage=config.numbers["p3_cataclysm"], target="all")
+        # Emergency self-heal if extremely low
+        hp_frac = self.hp / self.max_hp
+        if hp_frac <= 0.25 and self.cooldowns.get("self_heal", 0) == 0:
+            self.cooldowns["self_heal"] = 4
+            bus.publish("sfx.play", {"key": config.sfx["reconstitution"], "boss": name})
+            return HealSelfPercent("Oblivion Reconstitution", percent=0.2)
+        # Combo: Drain + single pulse
+        bus.publish("sfx.play", {"key": config.sfx["combo"], "boss": name})
+        return MultiAction(
+            name="Ravenous Combo",
+            actions=[
+                DrainAction("Heartseeker Drain", damage=config.numbers["p3_drain"], heal_ratio=0.5),
+                DamageAction("Shadow Pulse", damage=config.numbers["p3_st"], target="single"),
+            ],
+        )
+
+    phases = [
+        BossPhase(
+            definition=PhaseDefinition(
+                id="phase1",
+                threshold_pct=config.thresholds["phase1"],
+                music_track=config.music["phase1"],
+                enter_sfx=config.sfx["enter_p1"],
+            ),
+            on_choose_action=p1_ai,
+        ),
+        BossPhase(
+            definition=PhaseDefinition(
+                id="phase2",
+                threshold_pct=config.thresholds["phase2"],
+                music_track=config.music["phase2"],
+                enter_sfx=config.sfx["enter_p2"],
+            ),
+            on_choose_action=p2_ai,
+        ),
+        BossPhase(
+            definition=PhaseDefinition(
+                id="phase3",
+                threshold_pct=config.thresholds["phase3"],
+                music_track=config.music["phase3"],
+                enter_sfx=config.sfx["enter_p3"],
+            ),
+            on_choose_action=p3_ai,
+            on_enter=p3_enter,
+        ),
+    ]
+
+    boss = BaseBoss(
+        name=name,
+        max_hp=config.max_hp,
+        bus=bus,
+        save=save,
+        phases=phases,
+        death_sfx=config.sfx["death"],
+        relic_id="relic.final.oblivion_heart",
+        clear_flag="boss.b99.cleared",
+    )
+    return boss

--- a/src/amor_mortuorum/bosses/registry.py
+++ b/src/amor_mortuorum/bosses/registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Dict, Callable
+
+from .base import BaseBoss
+
+
+class BossRegistry:
+    def __init__(self) -> None:
+        self._factories: Dict[str, Callable[..., BaseBoss]] = {}
+
+    def register(self, boss_id: str, factory: Callable[..., BaseBoss]) -> None:
+        self._factories[boss_id] = factory
+
+    def create(self, boss_id: str, *args, **kwargs) -> BaseBoss:
+        if boss_id not in self._factories:
+            raise KeyError(f"Unknown boss id: {boss_id}")
+        return self._factories[boss_id](*args, **kwargs)
+
+
+registry = BossRegistry()

--- a/src/amor_mortuorum/combat/actions.py
+++ b/src/amor_mortuorum/combat/actions.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .actors import Actor, Party
+
+
+class Action:
+    name: str
+
+    def execute(self, boss: "BaseBoss", party: Party) -> Dict:
+        raise NotImplementedError
+
+
+@dataclass
+class DamageAction(Action):
+    name: str
+    damage: int
+    target: str  # 'single' or 'all'
+
+    def execute(self, boss: "BaseBoss", party: Party) -> Dict:
+        result: Dict = {"name": self.name, "type": "damage", "target": self.target, "applied": []}
+        if self.target == "all":
+            for m in party.alive_members():
+                dealt = m.receive_damage(self.damage)
+                result["applied"].append({"to": m.name, "damage": dealt})
+        else:  # single target: choose the actor with highest HP among alive
+            alive = party.alive_members()
+            if alive:
+                target = max(alive, key=lambda a: a.hp)
+                dealt = target.receive_damage(self.damage)
+                result["applied"].append({"to": target.name, "damage": dealt})
+        return result
+
+
+@dataclass
+class DrainAction(Action):
+    name: str
+    damage: int
+    heal_ratio: float  # 0..1
+
+    def execute(self, boss: "BaseBoss", party: Party) -> Dict:
+        result: Dict = {"name": self.name, "type": "drain", "applied": []}
+        alive = party.alive_members()
+        if alive:
+            target = max(alive, key=lambda a: a.hp)
+            dealt = target.receive_damage(self.damage)
+            healed = boss.heal(int(dealt * self.heal_ratio))
+            result["applied"].append({"to": target.name, "damage": dealt, "healed": healed})
+        return result
+
+
+@dataclass
+class HealSelfPercent(Action):
+    name: str
+    percent: float  # 0..1
+
+    def execute(self, boss: "BaseBoss", party: Party) -> Dict:
+        amount = int(boss.max_hp * self.percent)
+        healed = boss.heal(amount)
+        return {"name": self.name, "type": "heal", "healed": healed}
+
+
+@dataclass
+class MultiAction(Action):
+    name: str
+    actions: List[Action]
+
+    def execute(self, boss: "BaseBoss", party: Party) -> Dict:
+        results: List[Dict] = []
+        for act in self.actions:
+            results.append(act.execute(boss, party))
+        return {"name": self.name, "type": "multi", "steps": results}

--- a/src/amor_mortuorum/combat/actors.py
+++ b/src/amor_mortuorum/combat/actors.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Actor:
+    name: str
+    max_hp: int
+    hp: int
+
+    def is_alive(self) -> bool:
+        return self.hp > 0
+
+    def receive_damage(self, amount: int) -> int:
+        before = self.hp
+        self.hp = max(0, self.hp - max(0, amount))
+        return before - self.hp
+
+    def heal(self, amount: int) -> int:
+        before = self.hp
+        self.hp = min(self.max_hp, self.hp + max(0, amount))
+        return self.hp - before
+
+
+@dataclass
+class Party:
+    members: List[Actor] = field(default_factory=list)
+
+    def alive_members(self) -> List[Actor]:
+        return [m for m in self.members if m.is_alive()]
+
+    def is_wiped(self) -> bool:
+        return all(not m.is_alive() for m in self.members)
+
+    def total_hp(self) -> int:
+        return sum(m.hp for m in self.members)

--- a/src/amor_mortuorum/core/events.py
+++ b/src/amor_mortuorum/core/events.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Tuple
+
+
+@dataclass
+class Event:
+    type: str
+    payload: Dict[str, Any]
+
+
+class EventBus:
+    """
+    Minimal pub/sub event bus used to broadcast gameplay events such as SFX and music changes.
+    Also stores a history for testing and analytics.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, List[Callable[[Event], None]]] = {}
+        self._history: List[Event] = []
+
+    def subscribe(self, event_type: str, handler: Callable[[Event], None]) -> None:
+        self._subscribers.setdefault(event_type, []).append(handler)
+
+    def publish(self, event_type: str, payload: Dict[str, Any] | None = None) -> None:
+        evt = Event(event_type, payload or {})
+        self._history.append(evt)
+        for h in self._subscribers.get(event_type, []):
+            try:
+                h(evt)
+            except Exception:
+                # Avoid crashing the bus due to bad handler; in production use logging.
+                pass
+
+    @property
+    def history(self) -> Tuple[Event, ...]:
+        return tuple(self._history)
+
+    def clear_history(self) -> None:
+        self._history.clear()

--- a/src/amor_mortuorum/core/save.py
+++ b/src/amor_mortuorum/core/save.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class SaveService:
+    """Interface for save persistence."""
+
+    def set_flag(self, key: str, value: bool) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def get_flag(self, key: str, default: bool = False) -> bool:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def award_relic(self, relic_id: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def has_relic(self, relic_id: str) -> bool:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class InMemorySaveService(SaveService):
+    """
+    Test/deterministic in-memory save implementation.
+    Stores flags and awarded relics in dictionaries.
+    """
+
+    def __init__(self) -> None:
+        self._flags: Dict[str, bool] = {}
+        self._relics: Dict[str, bool] = {}
+
+    def set_flag(self, key: str, value: bool) -> None:
+        self._flags[key] = value
+
+    def get_flag(self, key: str, default: bool = False) -> bool:
+        return self._flags.get(key, default)
+
+    def award_relic(self, relic_id: str) -> None:
+        self._relics[relic_id] = True
+
+    def has_relic(self, relic_id: str) -> bool:
+        return self._relics.get(relic_id, False)

--- a/tests/test_oblivion_heart_boss.py
+++ b/tests/test_oblivion_heart_boss.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from amor_mortuorum.bosses.oblivion_heart import OHConfig, build_oblivion_heart
+from amor_mortuorum.core.events import EventBus
+from amor_mortuorum.core.save import InMemorySaveService
+from amor_mortuorum.combat.actors import Actor, Party
+
+
+def make_boss():
+    cfg = OHConfig.from_json(Path(__file__).parents[1] / "data" / "bosses" / "oblivion_heart.json")
+    bus = EventBus()
+    save = InMemorySaveService()
+    boss = build_oblivion_heart(cfg, bus, save)
+    boss.start_battle()
+    return boss, bus, save
+
+
+def test_phase_transitions_and_music_sfx():
+    boss, bus, _ = make_boss()
+
+    # On start, phase1 music/sfx should be published
+    assert any(e.type == "music.change" and e.payload.get("track") == "music.oblivion_heart.phase1" for e in bus.history)
+    assert any(e.type == "sfx.play" and e.payload.get("key") == "sfx.boss.oblivion_heart.phase1" for e in bus.history)
+
+    # Drop to 65% -> phase 2
+    boss.hp = int(boss.max_hp * 0.65)
+    boss.update_phase_if_needed()
+    assert any(e.type == "music.change" and e.payload.get("track") == "music.oblivion_heart.phase2" for e in bus.history)
+    assert any(e.type == "sfx.play" and e.payload.get("key") == "sfx.boss.oblivion_heart.phase2" for e in bus.history)
+
+    # Drop to 15% -> phase 3 (enrage)
+    boss.hp = int(boss.max_hp * 0.15)
+    boss.update_phase_if_needed()
+    assert any(e.type == "music.change" and e.payload.get("track") == "music.oblivion_heart.enraged" for e in bus.history)
+    assert any(e.type == "sfx.play" and e.payload.get("key") == "sfx.boss.oblivion_heart.enrage" for e in bus.history)
+    assert boss.status.get("enraged") is True
+
+
+def test_self_heal_check_in_phase2():
+    boss, bus, _ = make_boss()
+    # Move to phase 2 by reducing HP
+    boss.hp = int(boss.max_hp * 0.65)
+    boss.update_phase_if_needed()
+
+    # Put boss at 35% to trigger self-heal check, ensure cooldown ready
+    boss.hp = int(boss.max_hp * 0.35)
+    boss.cooldowns.clear()
+
+    party = Party([Actor("Hero", 1200, 1200), Actor("Mage", 800, 800)])
+
+    before = boss.hp
+    res = boss.take_turn(party)
+    assert res["type"] in ("heal", "multi")
+    assert boss.hp > before  # healed
+    assert any(e.type == "sfx.play" and e.payload.get("key") == "sfx.boss.reconstitution" for e in bus.history)
+
+
+def test_enrage_aoe_cataclysm_and_combo():
+    boss, bus, _ = make_boss()
+    # Force phase 3
+    boss.hp = int(boss.max_hp * 0.15)
+    boss.update_phase_if_needed()
+
+    party = Party([Actor("Hero", 1200, 1200), Actor("Mage", 800, 800), Actor("Rogue", 900, 900)])
+
+    # First turn in p3 should use Cataclysmic Beat if cooldown 0
+    boss.cooldowns["cataclysm"] = 0
+    res = boss.take_turn(party)
+    assert res["name"] == "Cataclysmic Beat"
+    # Everyone should take damage
+    assert all(m.hp < m.max_hp for m in party.members)
+
+    # Next turn: cooldown prevents cataclysm; expect combo or heal depending on HP
+    # Raise HP a bit to avoid heal
+    boss.hp = max(boss.hp, int(boss.max_hp * 0.3))
+    res2 = boss.take_turn(party)
+    assert res2["name"] in ("Ravenous Combo", "Cataclysmic Beat")
+
+
+def test_clear_condition_recorded_on_defeat():
+    boss, bus, save = make_boss()
+    # Kill the boss
+    boss.receive_damage(boss.hp)
+    assert save.get_flag("boss.b99.cleared") is True
+    assert save.has_relic("relic.final.oblivion_heart") is True
+    # Death SFX and music stop published
+    assert any(e.type == "sfx.play" and e.payload.get("key") == "sfx.boss.death" for e in bus.history)
+    assert any(e.type == "music.stop" for e in bus.history)


### PR DESCRIPTION
Automated implementation for issue #54:

Implementation overview:
- Added a new boss content module for the Final Boss (B99): Oblivion Heart. It features a three-phase encounter with explicit HP threshold triggers, phase-specific music and entry SFX, and post-defeat clear condition recording.

Architecture and design:
- Core components:
  - EventBus (core/events.py): lightweight pub/sub used to broadcast music and SFX events. Includes history for test assertions and gameplay telemetry.
  - SaveService (core/save.py): interface and InMemorySaveService for tests. Used by the boss to record the clear condition and award the final relic.
  - Combat primitives (combat/actors.py and combat/actions.py): minimal actor, party, and action classes supporting single-target damage, AOE damage, drain (damage + self-heal), self-heal-percent, and multi-step combos.
  - Boss framework (bosses/base.py): BaseBoss with phase management, event publication for phase entry, cooldown management, and defeat handling. PhaseDefinition and BossPhase allow decoupled audiovisuals and AI hooks per phase.
  - Boss registry (bosses/registry.py): Simple registry to register/create bosses if needed by the wider game.
  - Oblivion Heart (bosses/oblivion_heart.py): Data-driven construction from JSON config. Defines the AI per phase, thresholds, unique SFX/music, and special behaviors: AoE usage, self-heal checks, and Enrage. Enrage occurs on phase 3 entry (<20% HP) and toggles a status flag and Cataclysmic Beat behavior.
  - Data file (data/bosses/oblivion_heart.json): Configures thresholds (phase2 at 70%, phase3 at 20%), music tracks per phase, all SFX keys, and per-ability damage/values.

Behavior highlights meeting acceptance criteria:
- Multi-phase: Three phases with thresholds at 70% and 20% HP. Phase changes publish distinct music and SFX events. The current phase is tracked and transitions are deterministic from thresholds.
- Enrage: Phase 3 sets status["enraged"] and prioritizes a heavy AOE (Cataclysmic Beat) on cooldown. Entry plays an enrage SFX and swaps to an enraged track.
- AOE: Multiple AOEs across phases: Abyssal Maelstrom in phases 1–2, Cataclysmic Beat in phase 3.
- Self-heal checks: In phase 2 and 3, conditional self-heal (Oblivion Reconstitution) triggers when HP is low and not on cooldown. Drain skills also provide partial self-healing.
- Clear condition recorded: On defeat, the boss publishes death SFX, stops music, sets a clear flag (boss.b99.cleared), and awards the final relic relic.final.oblivion_heart.

Testing:
- tests/test_oblivion_heart_boss.py validates phase transitions and associated music/SFX, self-heal behavior, enrage AOE behavior, and clear condition recording. Tests use in-memory save and event bus with history ensuring deterministic assertions.

Integration points:
- The EventBus and SaveService interfaces allow integration into the existing application without requiring other systems. Real audio and UI systems would subscribe to the bus events to play tracks/SFX and update the UI. The boss registry can be used to expose this boss to the dungeon/boss loader. The data file allows balance tuning without code changes.

Notes:
- The implementation is self-contained and uses minimal dependencies. In a full integration, wire the EventBus to the central game bus and the SaveService to the actual save system. Replace action logic and actor/party implementations to match the game's combat engine while preserving the boss AI and phase logic.


Files created:
- src/amor_mortuorum/core/events.py
- src/amor_mortuorum/core/save.py
- src/amor_mortuorum/combat/actors.py
- src/amor_mortuorum/combat/actions.py
- src/amor_mortuorum/bosses/base.py
- src/amor_mortuorum/bosses/registry.py
- src/amor_mortuorum/bosses/oblivion_heart.py
- data/bosses/oblivion_heart.json
- tests/test_oblivion_heart_boss.py