### PR TITLE
Build App: Relics data & collection UI

### DIFF
--- a/data/relics.json
+++ b/data/relics.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "veil_fragment_1",
+    "name": "Veil Fragment I",
+    "description": "A shard of the Veil, faintly humming.",
+    "kind": "fragment",
+    "order": 1,
+    "icon": "assets/icons/relics/fragment_1.png"
+  },
+  {
+    "id": "veil_fragment_2",
+    "name": "Veil Fragment II",
+    "description": "Two pieces begin to resonate.",
+    "kind": "fragment",
+    "order": 2,
+    "icon": "assets/icons/relics/fragment_2.png"
+  },
+  {
+    "id": "veil_fragment_3",
+    "name": "Veil Fragment III",
+    "description": "The Veil stirs at your touch.",
+    "kind": "fragment",
+    "order": 3,
+    "icon": "assets/icons/relics/fragment_3.png"
+  },
+  {
+    "id": "veil_fragment_4",
+    "name": "Veil Fragment IV",
+    "description": "A whisper leaks through the tear.",
+    "kind": "fragment",
+    "order": 4,
+    "icon": "assets/icons/relics/fragment_4.png"
+  },
+  {
+    "id": "veil_fragment_5",
+    "name": "Veil Fragment V",
+    "description": "Half the Veil remembers you.",
+    "kind": "fragment",
+    "order": 5,
+    "icon": "assets/icons/relics/fragment_5.png"
+  },
+  {
+    "id": "veil_fragment_6",
+    "name": "Veil Fragment VI",
+    "description": "A current pulls from beyond.",
+    "kind": "fragment",
+    "order": 6,
+    "icon": "assets/icons/relics/fragment_6.png"
+  },
+  {
+    "id": "veil_fragment_7",
+    "name": "Veil Fragment VII",
+    "description": "The seams begin to align.",
+    "kind": "fragment",
+    "order": 7,
+    "icon": "assets/icons/relics/fragment_7.png"
+  },
+  {
+    "id": "veil_fragment_8",
+    "name": "Veil Fragment VIII",
+    "description": "Echoes of the dead steady your hand.",
+    "kind": "fragment",
+    "order": 8,
+    "icon": "assets/icons/relics/fragment_8.png"
+  },
+  {
+    "id": "veil_fragment_9",
+    "name": "Veil Fragment IX",
+    "description": "The Veil is almost whole.",
+    "kind": "fragment",
+    "order": 9,
+    "icon": "assets/icons/relics/fragment_9.png"
+  },
+  {
+    "id": "veil_final",
+    "name": "Relic of the Veil",
+    "description": "The Veil surrenders its last secret.",
+    "kind": "final",
+    "icon": "assets/icons/relics/final.png"
+  }
+]

--- a/src/amor/__init__.py
+++ b/src/amor/__init__.py
@@ -1,0 +1,13 @@
+"""
+Amor Mortuorum core package.
+
+This package contains core, meta-progression, and UI modules. The implementation in
+this iteration focuses on Relics (meta) data management and a Graveyard UI panel
+that displays collection progress.
+"""
+
+__all__ = [
+    "core",
+    "meta",
+    "ui",
+]

--- a/src/amor/core/events.py
+++ b/src/amor/core/events.py
@@ -1,0 +1,46 @@
+import logging
+from threading import RLock
+from typing import Callable, Dict, List, Any
+
+logger = logging.getLogger(__name__)
+
+
+class EventBus:
+    """A lightweight, thread-safe publish/subscribe event bus.
+
+    - Subscribers register handlers for event names (strings).
+    - Emit broadcasts payloads to all handlers of that event.
+
+    Intended for decoupling UI components and managers.
+    """
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._handlers: Dict[str, List[Callable[[Any], None]]] = {}
+
+    def subscribe(self, event: str, handler: Callable[[Any], None]) -> None:
+        """Subscribe a handler to an event name."""
+        with self._lock:
+            self._handlers.setdefault(event, []).append(handler)
+            logger.debug("Subscribed handler %s to event '%s'", getattr(handler, "__name__", str(handler)), event)
+
+    def unsubscribe(self, event: str, handler: Callable[[Any], None]) -> None:
+        """Unsubscribe a handler from an event name. Silently ignores if not present."""
+        with self._lock:
+            if event in self._handlers and handler in self._handlers[event]:
+                self._handlers[event].remove(handler)
+                logger.debug("Unsubscribed handler %s from event '%s'", getattr(handler, "__name__", str(handler)), event)
+
+    def emit(self, event: str, payload: Any = None) -> None:
+        """Emit an event with an optional payload to all subscribed handlers.
+
+        Handlers exceptions are caught and logged, allowing other handlers to still run.
+        """
+        with self._lock:
+            handlers = list(self._handlers.get(event, []))
+        logger.debug("Emitting event '%s' to %d handlers with payload: %r", event, len(handlers), payload)
+        for handler in handlers:
+            try:
+                handler(payload)
+            except Exception as exc:  # noqa: BLE001 - we want to log any exception from handlers
+                logger.exception("Error in event handler for '%s': %s", event, exc)

--- a/src/amor/meta/__init__.py
+++ b/src/amor/meta/__init__.py
@@ -1,0 +1,5 @@
+"""
+Meta-progression systems for Amor Mortuorum.
+
+This module currently includes relics data and collection management.
+"""

--- a/src/amor/meta/meta_store.py
+++ b/src/amor/meta/meta_store.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import logging
+from copy import deepcopy
+from pathlib import Path
+from threading import RLock
+from typing import Any, Callable, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class MetaStore:
+    """Thread-safe JSON store for meta-progression data (meta.json).
+
+    Provides atomic load/save/update helpers and ensures the directory exists.
+    """
+
+    CURRENT_VERSION = 1
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._lock = RLock()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            logger.info("meta.json not found at %s, creating with default schema", self.path)
+            self.save(self._default())
+
+    def _default(self) -> Dict[str, Any]:
+        return {
+            "version": self.CURRENT_VERSION,
+            "relics": {
+                "collected_ids": [],  # fragment ids only
+                "final_collected": False,
+            },
+        }
+
+    def load(self) -> Dict[str, Any]:
+        with self._lock:
+            try:
+                data = json.loads(self.path.read_text(encoding="utf-8"))
+                logger.debug("Loaded meta.json from %s: %r", self.path, data)
+                return data
+            except FileNotFoundError:
+                logger.warning("meta.json missing at %s; recreating default", self.path)
+                default = self._default()
+                self.save(default)
+                return deepcopy(default)
+
+    def save(self, data: Dict[str, Any]) -> None:
+        with self._lock:
+            self.path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+            logger.debug("Saved meta.json to %s", self.path)
+
+    def update(self, fn: Callable[[Dict[str, Any]], Dict[str, Any] | None]) -> Dict[str, Any]:
+        """Atomically load, transform, and save.
+
+        The provided function receives the current data and may modify it in-place
+        or return a new dict. The resulting dict is saved and returned.
+        """
+        with self._lock:
+            data = self.load()
+            result = fn(data)
+            if result is None:
+                result = data
+            self.save(result)
+            return deepcopy(result)

--- a/src/amor/meta/relics_data.py
+++ b/src/amor/meta/relics_data.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Relic:
+    """Immutable data for a Relic definition.
+
+    Attributes:
+        id: Unique identifier, e.g., 'veil_fragment_1' or 'veil_final'.
+        name: Display name.
+        description: Flavor text.
+        kind: 'fragment' or 'final'.
+        order: Order of the fragment (1..9) for fragments; None for final.
+        icon: Optional icon path reference (not used in tests but reserved for UI).
+    """
+
+    id: str
+    name: str
+    description: str
+    kind: str  # 'fragment' | 'final'
+    order: Optional[int] = None
+    icon: Optional[str] = None
+
+
+class RelicsData:
+    """Loads and validates relics definitions from a JSON data file.
+
+    Expects exactly 9 fragments and 1 final relic.
+    """
+
+    def __init__(self, relics: List[Relic]) -> None:
+        self._relics = relics
+        self._validate()
+        self._by_id: Dict[str, Relic] = {r.id: r for r in relics}
+        self._fragments_sorted: List[Relic] = sorted(
+            [r for r in relics if r.kind == "fragment"], key=lambda r: r.order or 0
+        )
+        self._final: Relic = next(r for r in relics if r.kind == "final")
+
+    def _validate(self) -> None:
+        fragments = [r for r in self._relics if r.kind == "fragment"]
+        finals = [r for r in self._relics if r.kind == "final"]
+        if len(fragments) != 9:
+            raise ValueError(f"Expected 9 fragment relics, found {len(fragments)}")
+        if len(finals) != 1:
+            raise ValueError(f"Expected 1 final relic, found {len(finals)}")
+        orders = [r.order for r in fragments]
+        if any(o is None for o in orders):
+            raise ValueError("All fragment relics must have an 'order' field")
+        if sorted(orders) != list(range(1, 10)):
+            raise ValueError("Fragment 'order' values must be 1..9 without gaps")
+        ids = [r.id for r in self._relics]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Duplicate relic ids found in data")
+
+    @classmethod
+    def from_file(cls, path: Path | str) -> "RelicsData":
+        path = Path(path)
+        logger.debug("Loading relics data from %s", path)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        relics: List[Relic] = []
+        for entry in raw:
+            relics.append(
+                Relic(
+                    id=entry["id"],
+                    name=entry["name"],
+                    description=entry.get("description", ""),
+                    kind=entry["kind"],
+                    order=entry.get("order"),
+                    icon=entry.get("icon"),
+                )
+            )
+        return cls(relics)
+
+    @property
+    def all(self) -> List[Relic]:
+        return list(self._relics)
+
+    @property
+    def fragments(self) -> List[Relic]:
+        return list(self._fragments_sorted)
+
+    @property
+    def fragment_ids(self) -> List[str]:
+        return [r.id for r in self._fragments_sorted]
+
+    @property
+    def final(self) -> Relic:
+        return self._final
+
+    def by_id(self, relic_id: str) -> Relic:
+        try:
+            return self._by_id[relic_id]
+        except KeyError:
+            raise KeyError(f"Unknown relic id: {relic_id}")

--- a/src/amor/meta/relics_manager.py
+++ b/src/amor/meta/relics_manager.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
+
+from .meta_store import MetaStore
+from .relics_data import RelicsData
+from ..core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RelicsSnapshot:
+    collected_ids: List[str]
+    final_collected: bool
+    collected_count: int
+    total_fragments: int
+
+
+class RelicsManager:
+    """Manages the collection state of Relics of the Veil and persistence to meta.json.
+
+    Emits 'relics:updated' events with a RelicsSnapshot payload when the state changes.
+    """
+
+    EVENT_UPDATED = "relics:updated"
+
+    def __init__(self, meta_store: MetaStore, relics_data: RelicsData, event_bus: EventBus) -> None:
+        self._store = meta_store
+        self._data = relics_data
+        self._bus = event_bus
+        self._fragment_ids: Set[str] = set()
+        self._final_collected: bool = False
+        self._load_from_store()
+
+    def _load_from_store(self) -> None:
+        data = self._store.load()
+        relics = data.get("relics", {})
+        collected = set(relics.get("collected_ids", []))
+        final_collected = bool(relics.get("final_collected", False))
+        # Sanitize: keep only known fragment ids and clamp to 9
+        known_fragments = set(self._data.fragment_ids)
+        self._fragment_ids = collected & known_fragments
+        self._final_collected = final_collected
+        if self._fragment_ids != collected or "relics" not in data:
+            # Save back sanitized/initialized structure
+            logger.info("Sanitizing meta relics section or initializing defaults")
+            self._persist()
+
+    def _persist(self) -> None:
+        def transform(d: Dict) -> Dict:
+            d.setdefault("version", self._store.CURRENT_VERSION)
+            d["relics"] = {
+                "collected_ids": sorted(self._fragment_ids, key=lambda x: self._data.fragment_ids.index(x)),
+                "final_collected": self._final_collected,
+            }
+            return d
+
+        saved = self._store.update(transform)
+        logger.debug("Persisted relics state: %r", saved.get("relics"))
+
+    def _emit(self) -> None:
+        snapshot = RelicsSnapshot(
+            collected_ids=self.collected_ids(),
+            final_collected=self._final_collected,
+            collected_count=self.collected_count(),
+            total_fragments=self.total_fragments(),
+        )
+        self._bus.emit(self.EVENT_UPDATED, snapshot)
+
+    # Public API
+
+    def collect_relic(self, relic_id: str) -> bool:
+        """Collect a fragment relic by id.
+
+        Returns True if this call added a new relic (state changed), False if it was already collected.
+        Raises KeyError if the id is unknown, or ValueError if the id is not a fragment relic.
+        """
+        relic = self._data.by_id(relic_id)
+        if relic.kind != "fragment":
+            raise ValueError(f"Relic '{relic_id}' is not a fragment and cannot be collected via collect_relic().")
+        if relic_id in self._fragment_ids:
+            logger.info("Relic '%s' already collected; ignoring.", relic_id)
+            return False
+        self._fragment_ids.add(relic_id)
+        self._persist()
+        self._emit()
+        logger.info("Collected relic '%s' (%d/%d)", relic_id, self.collected_count(), self.total_fragments())
+        return True
+
+    def collect_final_relic(self) -> bool:
+        """Mark the final relic as collected.
+
+        Returns True if state changed; False if already collected.
+        """
+        if self._final_collected:
+            logger.info("Final relic already collected; ignoring.")
+            return False
+        self._final_collected = True
+        self._persist()
+        self._emit()
+        logger.info("Collected final relic ")
+        return True
+
+    def is_collected(self, relic_id: str) -> bool:
+        relic = self._data.by_id(relic_id)
+        return relic.kind == "fragment" and relic_id in self._fragment_ids
+
+    def collected_ids(self) -> List[str]:
+        return sorted(self._fragment_ids, key=lambda x: self._data.fragment_ids.index(x))
+
+    def collected_count(self) -> int:
+        return len(self._fragment_ids)
+
+    def total_fragments(self) -> int:
+        return len(self._data.fragments)
+
+    def final_collected(self) -> bool:
+        return self._final_collected
+
+    def progress(self) -> Tuple[int, int, bool]:
+        return self.collected_count(), self.total_fragments(), self._final_collected
+
+    def reset(self) -> None:
+        """Reset in-memory and persisted relics state (for tests or debug)."""
+        self._fragment_ids.clear()
+        self._final_collected = False
+        self._persist()
+        self._emit()

--- a/src/amor/ui/__init__.py
+++ b/src/amor/ui/__init__.py
@@ -1,0 +1,6 @@
+"""
+UI components for Amor Mortuorum.
+
+For this iteration, we provide a simple text-based Graveyard relics panel
+that listens to relic updates and exposes a renderable text string.
+"""

--- a/src/amor/ui/graveyard/__init__.py
+++ b/src/amor/ui/graveyard/__init__.py
@@ -1,0 +1,3 @@
+"""
+Graveyard UI package.
+"""

--- a/src/amor/ui/graveyard/relics_panel.py
+++ b/src/amor/ui/graveyard/relics_panel.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from ...core.events import EventBus
+from ...meta.relics_manager import RelicsManager, RelicsSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class GraveyardRelicsPanel:
+    """A UI panel for the Graveyard that shows Relics collection progress.
+
+    This implementation is renderer-agnostic and simply maintains a text string.
+    In the actual game, integrate with Arcade to draw this text or icons.
+    """
+
+    def __init__(self, manager: RelicsManager, bus: EventBus) -> None:
+        self._manager = manager
+        self._bus = bus
+        self._text: str = ""
+        self._bus.subscribe(RelicsManager.EVENT_UPDATED, self._on_relics_updated)
+        # Initialize text from current state
+        self._refresh_text()
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def _on_relics_updated(self, snapshot: Optional[RelicsSnapshot]) -> None:
+        logger.debug("RelicsPanel received update: %r", snapshot)
+        self._refresh_text(snapshot)
+
+    def _refresh_text(self, snapshot: Optional[RelicsSnapshot] = None) -> None:
+        if snapshot is None:
+            c, t, f = self._manager.progress()
+        else:
+            c, t, f = snapshot.collected_count, snapshot.total_fragments, snapshot.final_collected
+        final_symbol = "\u2713" if f else "\u2717"  # ✓ / ✗
+        self._text = f"Relics: {c}/{t} | Final: {final_symbol}"
+
+    # Optional hook for Arcade-based on_draw():
+    # def on_draw(self):
+    #     arcade.draw_text(self._text, x, y, color, font_size)

--- a/tests/test_relics_meta_and_ui.py
+++ b/tests/test_relics_meta_and_ui.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from amor.core.events import EventBus
+from amor.meta.meta_store import MetaStore
+from amor.meta.relics_data import RelicsData
+from amor.meta.relics_manager import RelicsManager
+from amor.ui.graveyard.relics_panel import GraveyardRelicsPanel
+
+
+def load_relics_data() -> RelicsData:
+    data_path = Path(__file__).parent.parent / "data" / "relics.json"
+    return RelicsData.from_file(data_path)
+
+
+def test_graveyard_panel_updates_and_persists(tmp_path: Path):
+    # Arrange
+    meta_path = tmp_path / "meta.json"
+    store = MetaStore(meta_path)
+    bus = EventBus()
+    relics_data = load_relics_data()
+    mgr = RelicsManager(store, relics_data, bus)
+    panel = GraveyardRelicsPanel(mgr, bus)
+
+    # Initial state
+    assert mgr.collected_count() == 0
+    assert mgr.final_collected() is False
+    assert panel.text == "Relics: 0/9 | Final: \u2717"  # ✗
+
+    # Act: collect first fragment
+    first_fragment = relics_data.fragment_ids[0]
+    changed = mgr.collect_relic(first_fragment)
+
+    # Assert: state changed, UI updated, persisted
+    assert changed is True
+    assert mgr.collected_count() == 1
+    assert panel.text == "Relics: 1/9 | Final: \u2717"
+
+    saved = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert saved["relics"]["collected_ids"] == [first_fragment]
+    assert saved["relics"]["final_collected"] is False
+
+    # Collect duplicate should not change state
+    changed_dup = mgr.collect_relic(first_fragment)
+    assert changed_dup is False
+    assert mgr.collected_count() == 1
+    assert panel.text == "Relics: 1/9 | Final: \u2717"
+
+    # Collect remaining fragments
+    for fid in relics_data.fragment_ids[1:]:
+        mgr.collect_relic(fid)
+    assert mgr.collected_count() == 9
+    assert panel.text == "Relics: 9/9 | Final: \u2717"
+
+    # Collect final relic
+    changed_final = mgr.collect_final_relic()
+    assert changed_final is True
+    assert mgr.final_collected() is True
+    assert panel.text == "Relics: 9/9 | Final: \u2713"  # ✓
+
+    saved2 = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert saved2["relics"]["collected_ids"] == relics_data.fragment_ids
+    assert saved2["relics"]["final_collected"] is True
+
+
+def test_invalid_and_type_checks(tmp_path: Path):
+    meta_path = tmp_path / "meta.json"
+    store = MetaStore(meta_path)
+    bus = EventBus()
+    relics_data = load_relics_data()
+    mgr = RelicsManager(store, relics_data, bus)
+
+    # Unknown id should raise
+    try:
+        mgr.collect_relic("unknown_id")
+        assert False, "Expected KeyError"
+    except KeyError:
+        pass
+
+    # Collecting final via fragment method should raise
+    try:
+        mgr.collect_relic(relics_data.final.id)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Collecting final twice returns False second time
+    assert mgr.collect_final_relic() is True
+    assert mgr.collect_final_relic() is False


### PR DESCRIPTION
Automated implementation for issue #56:

Implementation overview:

- Data model and loading (src/amor/meta/relics_data.py): Defines a Relic dataclass and a RelicsData loader that reads data/relics.json. It validates that there are exactly 9 fragments with order 1..9 and exactly 1 final relic. The loader exposes fragment and final IDs and a map by ID.

- Meta persistence (src/amor/meta/meta_store.py): MetaStore is a thread-safe JSON persistence layer for meta.json. It ensures the directory exists, initializes with defaults if missing, and provides atomic load/save/update operations. The schema contains a version and a relics section with collected fragment IDs and final_collected flag.

- Relics state management (src/amor/meta/relics_manager.py): RelicsManager manages the in-memory collection state, interacts with MetaStore for persistence, and uses EventBus to emit 'relics:updated' events when the collection changes. It exposes methods to collect a fragment, collect the final relic, query progress, and reset state. It sanitizes loaded meta to keep only known fragment IDs and writes back cleaned data.

- Event bus (src/amor/core/events.py): A simple thread-safe pub/sub system for decoupling the manager and UI. It logs handler exceptions without breaking the broadcast.

- Graveyard UI panel (src/amor/ui/graveyard/relics_panel.py): A renderer-agnostic UI component that subscribes to relics updates and maintains a text string representing progress (e.g., "Relics: 3/9 | Final: ✓"). In the actual Arcade scene, draw this string at the desired coordinates; this separation keeps UI logic testable.

- Data file (data/relics.json): Provides 9 fragment relics and 1 final relic, with ids veil_fragment_1..9 and veil_final. Each fragment has an order field for proper sorting.

- Tests (tests/test_relics_meta_and_ui.py): End-to-end tests validate that collecting relics updates the UI and persists to meta.json. They cover initial state, collecting a new fragment, ignoring duplicates, collecting all fragments, marking the final relic, and error cases (unknown id, wrong kind).

Architecture decisions:
- Separation of concerns: Data definitions (RelicsData), persistence (MetaStore), domain logic (RelicsManager), and UI (GraveyardRelicsPanel) are cleanly separated and communicate via an EventBus. This makes the system modular and easy to integrate with the wider game loop and rendering system.
- No external dependencies: Uses built-in modules for portability and simplicity. Logging hooks are present for production observability.
- Renderer-agnostic UI: The panel provides a text attribute and an example Arcade hook comment to integrate with the actual game renderer without introducing heavy dependencies into tests.

Integration points:
- In the Graveyard scene setup, instantiate MetaStore with the game's save path (e.g., saves/meta.json), load RelicsData from data/relics.json, create EventBus (or use a shared one), then create RelicsManager and GraveyardRelicsPanel. Draw panel.text with your Arcade text rendering.
- When the player acquires a relic (e.g., via chest, boss drop), call RelicsManager.collect_relic(relic_id) or collect_final_relic() accordingly. The manager persists and the UI updates automatically via events.

This implementation satisfies the acceptance criteria: collecting a new relic updates the UI and persists to meta.json. It also handles duplicates and invalid input robustly.


Files created:
- src/amor/__init__.py
- src/amor/core/events.py
- src/amor/meta/__init__.py
- src/amor/meta/relics_data.py
- src/amor/meta/meta_store.py
- src/amor/meta/relics_manager.py
- src/amor/ui/__init__.py
- src/amor/ui/graveyard/__init__.py
- src/amor/ui/graveyard/relics_panel.py
- data/relics.json
- tests/test_relics_meta_and_ui.py