### PR TITLE
Build App: Tiled prefab support

### DIFF
--- a/src/amor/procgen/tiled_prefab.py
+++ b/src/amor/procgen/tiled_prefab.py
@@ -1,0 +1,347 @@
+import logging
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Iterable
+import xml.etree.ElementTree as ET
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TileLayer:
+    """Represents a single tile layer in a Tiled TMX map.
+
+    Attributes:
+        name: Layer name.
+        width: Number of tiles horizontally.
+        height: Number of tiles vertically.
+        data: 2D grid [y][x] of GIDs (0 means empty/no tile).
+    """
+    name: str
+    width: int
+    height: int
+    data: List[List[int]]
+
+    def gid_at(self, x: int, y: int) -> int:
+        return self.data[y][x]
+
+    def __repr__(self) -> str:  # pragma: no cover - for debugging only
+        return f"TileLayer(name={self.name!r}, {self.width}x{self.height})"
+
+
+class MapAdapter:
+    """Abstract adapter for interacting with a dungeon grid/map.
+
+    Implementations must provide methods for querying and modifying tile IDs and
+    collision flags on a grid with dimensions width x height.
+    """
+
+    def get_size(self) -> Tuple[int, int]:
+        raise NotImplementedError
+
+    def get_tile(self, x: int, y: int) -> int:
+        raise NotImplementedError
+
+    def set_tile(self, x: int, y: int, gid: int) -> None:
+        raise NotImplementedError
+
+    def is_blocked(self, x: int, y: int) -> bool:
+        raise NotImplementedError
+
+    def set_blocked(self, x: int, y: int, blocked: bool) -> None:
+        raise NotImplementedError
+
+
+class GridMap(MapAdapter):
+    """Simple in-memory grid implementation for testing and integration.
+
+    Stores an integer tile layer and a boolean collision mask.
+    """
+
+    def __init__(self, width: int, height: int, default_gid: int = 0, default_blocked: bool = False) -> None:
+        if width <= 0 or height <= 0:
+            raise ValueError("GridMap width and height must be positive")
+        self.width = width
+        self.height = height
+        self._tiles: List[List[int]] = [[default_gid for _ in range(width)] for _ in range(height)]
+        self._blocked: List[List[bool]] = [[default_blocked for _ in range(width)] for _ in range(height)]
+
+    def get_size(self) -> Tuple[int, int]:
+        return self.width, self.height
+
+    def get_tile(self, x: int, y: int) -> int:
+        return self._tiles[y][x]
+
+    def set_tile(self, x: int, y: int, gid: int) -> None:
+        self._tiles[y][x] = gid
+
+    def is_blocked(self, x: int, y: int) -> bool:
+        return self._blocked[y][x]
+
+    def set_blocked(self, x: int, y: int, blocked: bool) -> None:
+        self._blocked[y][x] = blocked
+
+    def __repr__(self) -> str:  # pragma: no cover - debug only
+        return f"GridMap({self.width}x{self.height})"
+
+
+class TiledPrefab:
+    """Prefab loaded from a Tiled (.tmx) file.
+
+    Supports basic orthogonal maps with CSV-encoded tile layers and an optional
+    Object Layer named "Collisions" (or similar) containing rectangle objects
+    denoting blocked tiles. Collisions will be rasterized per tile.
+
+    Limitations:
+    - Only encoding="csv" tile data is supported (no base64/compression).
+    - Orthogonal maps only.
+    - Collision objects: rectangles are supported. Other shapes are ignored.
+    - Tile GIDs are preserved as-is; any tileset images are ignored.
+    """
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        tilewidth: int,
+        tileheight: int,
+        tile_layers: List[TileLayer],
+        collision_mask: Optional[List[List[bool]]] = None,
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.tilewidth = tilewidth
+        self.tileheight = tileheight
+        self.tile_layers = tile_layers
+        # Default to all False if none provided
+        self.collision_mask: List[List[bool]] = collision_mask if collision_mask is not None else [
+            [False for _ in range(width)] for _ in range(height)
+        ]
+
+    @property
+    def primary_layer(self) -> TileLayer:
+        """Return the intended primary tile layer to stamp.
+
+        If a layer named "Tiles" exists, prefer it; otherwise use the first tile layer.
+        """
+        for layer in self.tile_layers:
+            if layer.name.lower() == "tiles":
+                return layer
+        return self.tile_layers[0]
+
+    def solid_at(self, x: int, y: int) -> bool:
+        return self.collision_mask[y][x]
+
+    @classmethod
+    def from_tmx(
+        cls,
+        path: str,
+        collision_layer_names: Iterable[str] = ("collisions", "collision", "blockers", "blocks"),
+    ) -> "TiledPrefab":
+        """Load a Tiled TMX file and build a TiledPrefab.
+
+        Args:
+            path: Path to .tmx file.
+            collision_layer_names: Object layer names considered as collision sources.
+
+        Returns:
+            TiledPrefab instance.
+        """
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"TMX file not found: {path}")
+
+        logger.debug("Loading TMX prefab from %s", path)
+        tree = ET.parse(path)
+        root = tree.getroot()
+
+        # Validate map type
+        orientation = root.attrib.get("orientation", "orthogonal")
+        if orientation != "orthogonal":
+            raise ValueError(f"Only orthogonal maps are supported, got orientation={orientation}")
+
+        width = int(root.attrib["width"])
+        height = int(root.attrib["height"])
+        tilewidth = int(root.attrib["tilewidth"]) if "tilewidth" in root.attrib else 1
+        tileheight = int(root.attrib["tileheight"]) if "tileheight" in root.attrib else 1
+
+        # Parse tile layers (CSV only)
+        tile_layers: List[TileLayer] = []
+        for layer_el in root.findall("layer"):
+            name = layer_el.attrib.get("name", "Layer")
+            lwidth = int(layer_el.attrib.get("width", width))
+            lheight = int(layer_el.attrib.get("height", height))
+            if lwidth != width or lheight != height:
+                raise ValueError(
+                    f"Layer {name!r} has size {lwidth}x{lheight} not matching map {width}x{height}"
+                )
+            data_el = layer_el.find("data")
+            if data_el is None:
+                raise ValueError(f"Layer {name!r} has no <data>")
+            encoding = data_el.attrib.get("encoding", "")
+            if encoding != "csv":
+                raise ValueError(
+                    f"Layer {name!r} data encoding={encoding!r} is unsupported (only 'csv' is supported)"
+                )
+            # Normalize and parse CSV; allow newlines and trailing commas
+            raw = (data_el.text or "").replace("\n", ",").replace("\r", ",")
+            parts = [p.strip() for p in raw.split(",")]
+            nums = [int(p) for p in parts if p != ""]
+            if len(nums) != width * height:
+                raise ValueError(
+                    f"Layer {name!r} has {len(nums)} gids but expected {width * height} (width*height)"
+                )
+            # Build 2D grid [y][x]
+            grid: List[List[int]] = []
+            it = iter(nums)
+            for _row in range(height):
+                row: List[int] = []
+                for _col in range(width):
+                    row.append(next(it))
+                grid.append(row)
+            tile_layers.append(TileLayer(name=name, width=width, height=height, data=grid))
+
+        if not tile_layers:
+            raise ValueError("TMX must contain at least one tile layer")
+
+        # Parse collisions from object groups with accepted names
+        collision_mask: List[List[bool]] = [[False for _ in range(width)] for _ in range(height)]
+        lower_names = {n.lower() for n in collision_layer_names}
+        for og_el in root.findall("objectgroup"):
+            og_name = og_el.attrib.get("name", "").lower()
+            if og_name not in lower_names:
+                continue
+            for obj in og_el.findall("object"):
+                # Only rectangle objects are supported (polygon/polyline will be ignored)
+                # Tiled rectangle objects have width/height attributes and no 'polygon' child.
+                if obj.find("polygon") is not None or obj.find("polyline") is not None:
+                    logger.warning("Ignoring non-rect collision object in layer %s", og_name)
+                    continue
+                x = float(obj.attrib.get("x", "0"))
+                y = float(obj.attrib.get("y", "0"))
+                w = float(obj.attrib.get("width", "0"))
+                h = float(obj.attrib.get("height", "0"))
+                # Convert pixel coords to tile coords (rounding down)
+                tx0 = int(x // tilewidth)
+                ty0 = int(y // tileheight)
+                tx1 = int((x + w - 1e-6) // tilewidth)
+                ty1 = int((y + h - 1e-6) // tileheight)
+                for ty in range(max(0, ty0), min(height, ty1 + 1)):
+                    for tx in range(max(0, tx0), min(width, tx1 + 1)):
+                        collision_mask[ty][tx] = True
+
+        return cls(
+            width=width,
+            height=height,
+            tilewidth=tilewidth,
+            tileheight=tileheight,
+            tile_layers=tile_layers,
+            collision_mask=collision_mask,
+        )
+
+
+@dataclass
+class StampOptions:
+    """Options controlling prefab stamping behavior."""
+
+    respect_collisions: bool = True  # Prevent stamping if any collision overlap
+    apply_collisions: bool = True    # Write prefab collision mask into target map
+    overwrite_tiles: bool = True     # Replace target tiles with non-zero prefab tiles
+
+
+class PrefabStamper:
+    """Applies TiledPrefab instances into a MapAdapter grid."""
+
+    @staticmethod
+    def can_stamp(
+        target: MapAdapter,
+        prefab: TiledPrefab,
+        dest_x: int,
+        dest_y: int,
+        options: Optional[StampOptions] = None,
+    ) -> bool:
+        """Check whether the prefab can be stamped at the given location.
+
+        Validates bounds and (optionally) collision overlaps.
+        """
+        if options is None:
+            options = StampOptions()
+
+        tw, th = target.get_size()
+        # Bounds check
+        if dest_x < 0 or dest_y < 0:
+            return False
+        if dest_x + prefab.width > tw or dest_y + prefab.height > th:
+            return False
+
+        if not options.respect_collisions:
+            return True
+
+        # Collision overlap: if any tile in prefab with solid collision would overlap a blocked tile
+        for py in range(prefab.height):
+            for px in range(prefab.width):
+                # Only consider cells that will affect the map: either have a tile or a collision
+                has_tile = prefab.primary_layer.gid_at(px, py) != 0
+                has_coll = prefab.solid_at(px, py)
+                if not (has_tile or has_coll):
+                    continue
+                tx = dest_x + px
+                ty = dest_y + py
+                if target.is_blocked(tx, ty):
+                    return False
+        return True
+
+    @staticmethod
+    def stamp(
+        target: MapAdapter,
+        prefab: TiledPrefab,
+        dest_x: int,
+        dest_y: int,
+        options: Optional[StampOptions] = None,
+    ) -> bool:
+        """Stamp the prefab into the target map at top-left (dest_x, dest_y).
+
+        Returns True if stamping succeeded; False if blocked by collisions or bounds when
+        respect_collisions is enabled. No partial writes occur on failure.
+        """
+        if options is None:
+            options = StampOptions()
+
+        if not PrefabStamper.can_stamp(target, prefab, dest_x, dest_y, options):
+            logger.info("Prefab cannot be stamped at %s,%s due to bounds/collision", dest_x, dest_y)
+            return False
+
+        # Apply tiles and collisions. To avoid partial writes in case of unexpected errors,
+        # we accumulate intended writes then apply.
+        writes_tiles: List[Tuple[int, int, int]] = []  # (x, y, gid)
+        writes_blocks: List[Tuple[int, int, bool]] = []
+
+        layer = prefab.primary_layer
+        for py in range(prefab.height):
+            for px in range(prefab.width):
+                gid = layer.gid_at(px, py)
+                if gid != 0 and options.overwrite_tiles:
+                    writes_tiles.append((dest_x + px, dest_y + py, gid))
+                if options.apply_collisions and prefab.solid_at(px, py):
+                    writes_blocks.append((dest_x + px, dest_y + py, True))
+
+        # Apply writes
+        try:
+            for (x, y, gid) in writes_tiles:
+                target.set_tile(x, y, gid)
+            for (x, y, blocked) in writes_blocks:
+                target.set_blocked(x, y, blocked)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.exception("Failed stamping prefab: %s", e)
+            return False
+
+        return True
+
+
+__all__ = [
+    "TiledPrefab",
+    "TileLayer",
+    "MapAdapter",
+    "GridMap",
+    "StampOptions",
+    "PrefabStamper",
+]

--- a/tests/test_tiled_prefab.py
+++ b/tests/test_tiled_prefab.py
@@ -1,0 +1,132 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from amor.procgen.tiled_prefab import TiledPrefab, GridMap, PrefabStamper, StampOptions
+
+
+def write_tmx(tmp_path: Path) -> Path:
+    # Minimal TMX map: 4x3 tiles, CSV data, 1 tile layer and 1 collisions object layer
+    content = """<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.8" tiledversion="1.8.6" orientation="orthogonal" renderorder="right-down" width="4" height="3" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="2">
+ <tileset firstgid="1" name="dummy" tilewidth="16" tileheight="16" tilecount="1" columns="1">
+  <image source="dummy.png" width="16" height="16"/>
+ </tileset>
+ <layer id="1" name="Tiles" width="4" height="3">
+  <data encoding="csv">
+1,1,0,0,
+1,1,0,0,
+0,0,0,0
+  </data>
+ </layer>
+ <objectgroup id="2" name="Collisions">
+  <!-- Rectangle covering tiles (1,0) and (1,1) given tile size 16x16 -->
+  <object id="1" x="16" y="0" width="16" height="32"/>
+ </objectgroup>
+</map>
+"""
+    tmx_path = tmp_path / "prefab.tmx"
+    tmx_path.write_text(content, encoding="utf-8")
+    return tmx_path
+
+
+def test_load_tmx_and_basic_properties(tmp_path: Path):
+    tmx_path = write_tmx(tmp_path)
+    prefab = TiledPrefab.from_tmx(str(tmx_path))
+    assert prefab.width == 4
+    assert prefab.height == 3
+    assert prefab.tilewidth == 16
+    assert prefab.tileheight == 16
+    # Primary layer should be named 'Tiles'
+    assert prefab.primary_layer.name == "Tiles"
+    # Check tile values
+    # Top-left 2x2 should be 1s
+    for y in range(2):
+        for x in range(2):
+            assert prefab.primary_layer.gid_at(x, y) == 1
+    # Collisions at (1,0) and (1,1)
+    assert prefab.solid_at(1, 0) is True
+    assert prefab.solid_at(1, 1) is True
+    assert prefab.solid_at(0, 0) is False
+
+
+def test_stamp_success_and_collisions_applied(tmp_path: Path):
+    tmx_path = write_tmx(tmp_path)
+    prefab = TiledPrefab.from_tmx(str(tmx_path))
+
+    # Create a 10x10 grid map
+    g = GridMap(10, 10)
+    # Stamp at (2,3)
+    ok = PrefabStamper.stamp(g, prefab, 2, 3)
+    assert ok is True
+
+    # Tiles should be stamped at (2,3),(3,3),(2,4),(3,4)
+    for x, y in [(2, 3), (3, 3), (2, 4), (3, 4)]:
+        assert g.get_tile(x, y) == 1
+
+    # Collisions from prefab should be applied at offset (1,0) and (1,1) -> (3,3) and (3,4)
+    assert g.is_blocked(3, 3) is True
+    assert g.is_blocked(3, 4) is True
+    # Neighbor not in collisions mask remains unblocked
+    assert g.is_blocked(2, 3) is False
+
+
+def test_stamp_respects_existing_collisions(tmp_path: Path):
+    tmx_path = write_tmx(tmp_path)
+    prefab = TiledPrefab.from_tmx(str(tmx_path))
+
+    g = GridMap(10, 10)
+    # Pre-block a cell that prefab would touch: prefab collision at local (1,0) => global (5,6)
+    g.set_blocked(5, 6, True)
+
+    # Attempt to stamp at (4,6) should fail due to collision overlap
+    ok = PrefabStamper.stamp(g, prefab, 4, 6, options=StampOptions(respect_collisions=True))
+    assert ok is False
+
+    # Ensure no tiles were written at the expected positions
+    assert g.get_tile(4, 6) == 0
+    assert g.get_tile(5, 6) == 0
+
+
+def test_stamp_out_of_bounds_fails(tmp_path: Path):
+    tmx_path = write_tmx(tmp_path)
+    prefab = TiledPrefab.from_tmx(str(tmx_path))
+
+    g = GridMap(5, 5)
+    # Placing at (3,3) would exceed (3+4 > 5)
+    ok = PrefabStamper.stamp(g, prefab, 3, 3)
+    assert ok is False
+
+
+def test_can_override_collision_respect(tmp_path: Path):
+    tmx_path = write_tmx(tmp_path)
+    prefab = TiledPrefab.from_tmx(str(tmx_path))
+
+    g = GridMap(10, 10)
+    # Pre-block a cell that prefab would touch
+    g.set_blocked(3, 3, True)
+
+    # With respect_collisions=False, placement is allowed (though usually not recommended)
+    ok = PrefabStamper.stamp(g, prefab, 2, 3, options=StampOptions(respect_collisions=False))
+    assert ok is True
+
+    # Tiles still stamped
+    assert g.get_tile(2, 3) == 1
+    assert g.get_tile(3, 3) == 1
+
+
+def test_invalid_encoding_rejected(tmp_path: Path):
+    # Same as write_tmx but with base64 encoding -> should raise ValueError
+    content = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<map version=\"1.8\" tiledversion=\"1.8.6\" orientation=\"orthogonal\" renderorder=\"right-down\" width=\"2\" height=\"2\" tilewidth=\"16\" tileheight=\"16\" infinite=\"0\" nextlayerid=\"2\" nextobjectid=\"1\"> 
+ <layer id=\"1\" name=\"Tiles\" width=\"2\" height=\"2\"> 
+  <data encoding=\"base64\">AAAA</data> 
+ </layer> 
+</map> 
+"""
+    tmx_path = tmp_path / "bad.tmx"
+    tmx_path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        TiledPrefab.from_tmx(str(tmx_path))


### PR DESCRIPTION
Automated implementation for issue #67:

Implementation overview:
- Created a lightweight TMX prefab loader (src/amor/procgen/tiled_prefab.py) that parses orthogonal .tmx maps with CSV tile layers and an optional collision object layer. It avoids external dependencies and focuses on data relevant for stamping: tile IDs and collision rectangles.
- Provided core domain classes:
  - TiledPrefab: encapsulates the prefab data (tile layers, collision mask). Supports choosing a primary layer (prefers a layer named "Tiles").
  - TileLayer: a simple layer data holder with a gid_at accessor.
  - MapAdapter: abstract map interface to integrate with the game's existing map system.
  - GridMap: in-memory implementation for testing and as a reference adaptor with tiles and collision flags.
  - StampOptions: controls stamping behavior (respect collisions, apply collisions, overwrite tiles).
  - PrefabStamper: performs bounds/collision checks and applies prefab tiles and collision data into a target MapAdapter. It guarantees no partial writes if can_stamp fails.

Key behaviors:
- Bounds checking ensures prefabs don't exceed target map dimensions.
- Collision handling: if respect_collisions=True (default), stamping fails if any target cell already blocked would overlap a tile or collision from the prefab. After successful stamping, prefab collision mask is written to the target if apply_collisions=True.
- Only non-zero tile GIDs are written (0 is treated as empty/transparent).

Tests:
- tests/test_tiled_prefab.py includes comprehensive unit tests that:
  - Validate TMX parsing (dimensions, layers, collisions).
  - Verify successful stamping and collision application.
  - Ensure stamping fails when overlapping pre-existing blocked tiles.
  - Handle out-of-bounds placement.
  - Allow overriding collision-respect behavior for special cases.
  - Reject unsupported encodings (base64) explicitly.

Design and integration notes:
- The MapAdapter abstraction is intended to integrate with the project's real map grid. Implement an adapter over the existing tile/collision storage to connect this system to your dungeon generator.
- Collision sources are read from object layers named (case-insensitive) among {"Collisions", "Collision", "Blockers", "Blocks"}. This can be adjusted by passing collision_layer_names to from_tmx.
- This module purposefully avoids tileset/image details and focuses on GIDs and collision metadata, which should be sufficient for stamping prefab rooms into a procedural level layout.
- The stamping API is deterministic and side-effect free when can_stamp fails, aiding reproducible tests and generation.

Error handling and logging:
- Rich validation with clear exceptions for unsupported formats.
- Logging points at load and stamping decisions for easier debugging.

How to use in procedural generation:
- Load your prefab once at startup: prefab = TiledPrefab.from_tmx("data/prefabs/treasure_room.tmx")
- During level generation, pick a placement and check: if PrefabStamper.can_stamp(map_adapter, prefab, x, y): PrefabStamper.stamp(map_adapter, prefab, x, y)
- The collisions from the prefab will be respected and written into the map, ensuring gameplay-accurate blocking.

This addresses the acceptance criteria by enabling import of .tmx room templates and stamping them into generated maps with collision logic respected.


Files created:
- src/amor/procgen/tiled_prefab.py
- tests/test_tiled_prefab.py