### PR TITLE
Build App: Debug overlay (F3)

### DIFF
--- a/src/amor/__init__.py
+++ b/src/amor/__init__.py
@@ -1,0 +1,8 @@
+from .debug.overlay import DebugOverlay, GameTelemetry, OverlayStyle, FPSCounter
+
+__all__ = [
+    "DebugOverlay",
+    "GameTelemetry",
+    "OverlayStyle",
+    "FPSCounter",
+]

--- a/src/amor/debug/__init__.py
+++ b/src/amor/debug/__init__.py
@@ -1,0 +1,8 @@
+from .overlay import DebugOverlay, GameTelemetry, OverlayStyle, FPSCounter
+
+__all__ = [
+    "DebugOverlay",
+    "GameTelemetry",
+    "OverlayStyle",
+    "FPSCounter",
+]

--- a/src/amor/debug/overlay.py
+++ b/src/amor/debug/overlay.py
@@ -1,0 +1,317 @@
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Optional, Union
+
+try:
+    import arcade
+except Exception:  # pragma: no cover - allow import in non-GL environments
+    arcade = None  # type: ignore
+
+Number = Union[int, float]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OverlayStyle:
+    """Visual configuration for the debug overlay.
+
+    Attributes:
+        font_name: Preferred font family (use monospace for aligned columns).
+        font_size: Font size in points.
+        text_color: RGBA tuple for text color.
+        background_color: RGBA tuple for background rectangle (with alpha for translucency).
+        margin: Outer margin from window edges (pixels).
+        padding: Inner padding inside the background box (pixels).
+        line_height: Vertical spacing between lines. If None, defaults to font_size * 1.2.
+        max_width: Hard cap for background width (None means auto from content).
+        anchor: Corner where the overlay is anchored. One of: "top-left", "top-right",
+                "bottom-left", "bottom-right".
+    """
+
+    font_name: str = "Courier New"
+    font_size: int = 14
+    text_color: tuple = (255, 255, 255, 255)
+    background_color: tuple = (0, 0, 0, 180)
+    margin: int = 8
+    padding: int = 8
+    line_height: Optional[int] = None
+    max_width: Optional[int] = None
+    anchor: str = "top-left"
+
+    def resolved_line_height(self) -> int:
+        return int(self.line_height or (self.font_size * 1.2))
+
+
+@dataclass
+class GameTelemetry:
+    """Holds the data points displayed by the debug overlay.
+
+    All fields are optional. Missing values are rendered as "-" in the overlay.
+    """
+
+    seed: Optional[Union[int, str]] = None
+    floor: Optional[int] = None
+    entity_counts: Dict[str, int] = field(default_factory=dict)
+    extras: Dict[str, Union[str, Number]] = field(default_factory=dict)
+
+    def update_entities(self, entities: Mapping[str, int] | Iterable[str]) -> None:
+        """Update entity counts.
+
+        Accepts either:
+        - a mapping of category -> count, or
+        - an iterable of category names (each increments its category by one)
+        """
+        if isinstance(entities, Mapping):
+            self.entity_counts = {str(k): int(v) for k, v in entities.items()}
+        else:
+            counts: Dict[str, int] = {}
+            for name in entities:
+                counts[str(name)] = counts.get(str(name), 0) + 1
+            self.entity_counts = counts
+
+    def set_extra(self, key: str, value: Union[str, Number]) -> None:
+        self.extras[str(key)] = value
+
+
+class FPSCounter:
+    """Simple rolling FPS estimator based on a time window of recent frames.
+
+    Keeps recent frame delta times and computes FPS as N / sum(dt) over the window.
+    By default uses the last 1.0 seconds of frame history for a stable reading.
+    """
+
+    def __init__(self, time_window: float = 1.0) -> None:
+        self.time_window = float(time_window)
+        self._dts: List[float] = []
+        self._accum: float = 0.0
+        self._fps: float = 0.0
+
+    @property
+    def fps(self) -> float:
+        return self._fps
+
+    def reset(self) -> None:
+        self._dts.clear()
+        self._accum = 0.0
+        self._fps = 0.0
+
+    def update(self, dt: float) -> float:
+        if dt <= 0:
+            return self._fps
+        self._dts.append(dt)
+        self._accum += dt
+        while self._accum > self.time_window and self._dts:
+            oldest = self._dts.pop(0)
+            self._accum -= oldest
+        total_time = max(1e-6, sum(self._dts))
+        frames = len(self._dts)
+        self._fps = frames / total_time
+        return self._fps
+
+
+class DebugOverlay:
+    """Interactive debug overlay for in-game telemetry.
+
+    Features:
+    - Toggle with F3 key (call on_key_press from your window/scene)
+    - Shows FPS, PRNG seed, floor, and entity category counts
+    - Draws a translucent background for legibility
+
+    Integration:
+        overlay = DebugOverlay(enabled=False)
+
+        # In your window/scene update loop:
+        def on_update(self, dt):
+            overlay.on_update(dt)
+
+        # In your window/scene draw:
+        def on_draw(self):
+            ...  # draw game
+            overlay.on_draw()
+
+        # In your window/scene key handling:
+        def on_key_press(self, key, modifiers):
+            overlay.on_key_press(key, modifiers)
+
+        # Update telemetry from your game state periodically
+        overlay.telemetry.seed = world.seed
+        overlay.telemetry.floor = world.depth
+        overlay.telemetry.update_entities({
+            "mobs": len(world.mobs),
+            "items": len(world.items),
+            "projectiles": len(world.projectiles),
+        })
+    """
+
+    def __init__(
+        self,
+        telemetry: Optional[GameTelemetry] = None,
+        *,
+        enabled: bool = False,
+        style: Optional[OverlayStyle] = None,
+    ) -> None:
+        self.telemetry: GameTelemetry = telemetry or GameTelemetry()
+        self.enabled: bool = enabled
+        self.style = style or OverlayStyle()
+        self._fps = FPSCounter()
+        self._cached_lines: List[str] = []
+        self._cache_invalid: bool = True
+
+    # ------------- Public API -------------
+    def set_enabled(self, value: bool) -> None:
+        self.enabled = bool(value)
+
+    def toggle(self) -> None:
+        self.enabled = not self.enabled
+
+    def on_key_press(self, key: int, modifiers: int) -> None:
+        if arcade is None:
+            return
+        if key == arcade.key.F3:
+            self.toggle()
+
+    def on_update(self, dt: float) -> None:
+        """Advance internal counters such as FPS. Safe to call even when disabled."""
+        self._fps.update(dt)
+        # Invalidate cached lines because FPS has changed per frame
+        self._cache_invalid = True
+
+    def on_draw(self) -> None:
+        """Render the overlay if enabled.
+
+        This is a no-op if there is no active Arcade window or overlay is disabled.
+        """
+        if not self.enabled:
+            return
+        if arcade is None:
+            logger.debug("Arcade not available; skipping overlay draw")
+            return
+
+        window = arcade.get_window()
+        if window is None:
+            logger.debug("No active window; skipping overlay draw")
+            return
+
+        lines = self.compose_lines()
+        if not lines:
+            return
+
+        # Calculate layout
+        style = self.style
+        line_height = style.resolved_line_height()
+        max_chars = max((len(line) for line in lines), default=0)
+        char_px = max(6, int(style.font_size * 0.6))  # rough monospace estimate
+        content_width = max_chars * char_px
+        if style.max_width is not None:
+            content_width = min(content_width, style.max_width)
+        box_width = content_width + style.padding * 2
+        box_height = len(lines) * line_height + style.padding * 2
+
+        # Determine anchored box rectangle
+        margin = style.margin
+        left: float
+        right: float
+        top: float
+        bottom: float
+        if style.anchor == "top-left":
+            left = margin
+            right = left + box_width
+            top = window.height - margin
+            bottom = top - box_height
+        elif style.anchor == "top-right":
+            right = window.width - margin
+            left = right - box_width
+            top = window.height - margin
+            bottom = top - box_height
+        elif style.anchor == "bottom-left":
+            left = margin
+            right = left + box_width
+            bottom = margin
+            top = bottom + box_height
+        elif style.anchor == "bottom-right":
+            right = window.width - margin
+            left = right - box_width
+            bottom = margin
+            top = bottom + box_height
+        else:
+            logger.warning("Unknown overlay anchor '%s', using top-left", style.anchor)
+            left = margin
+            right = left + box_width
+            top = window.height - margin
+            bottom = top - box_height
+
+        # Background
+        arcade.draw_lrtb_rectangle_filled(left, right, top, bottom, style.background_color)
+
+        # Text lines
+        x = left + style.padding
+        y = top - style.padding - line_height
+        for line in lines:
+            try:
+                text = arcade.Text(
+                    line,
+                    x=x,
+                    y=y,
+                    color=style.text_color,
+                    font_name=style.font_name,
+                    font_size=style.font_size,
+                    anchor_x="left",
+                    anchor_y="bottom",
+                )
+                text.draw()
+            except Exception as e:  # pragma: no cover - draw safety
+                logger.exception("Failed to draw overlay text: %s", e)
+            y -= line_height
+
+    # ------------- Composition -------------
+    def compose_lines(self) -> List[str]:
+        """Create the textual lines to render. Safe for testing without a window."""
+        if not self._cache_invalid:
+            return list(self._cached_lines)
+
+        t = self.telemetry
+        fps_val = self._fps.fps
+        try:
+            # Prefer arcade's internal FPS if available; fallback to computed
+            if arcade is not None:
+                win = arcade.get_window()
+                if win is not None and hasattr(arcade, "get_fps"):
+                    fps_val = float(arcade.get_fps())  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+        lines: List[str] = []
+        lines.append(f"FPS: {fps_val:5.1f}")
+        seed_str = "-" if t.seed in (None, "", []) else str(t.seed)
+        floor_str = "-" if t.floor in (None,) else str(t.floor)
+        lines.append(f"Seed:  {seed_str}")
+        lines.append(f"Floor: {floor_str}")
+
+        if t.entity_counts:
+            total = sum(max(0, int(v)) for v in t.entity_counts.values())
+            parts = [f"{k}={int(v)}" for k, v in sorted(t.entity_counts.items())]
+            ent_line = f"Entities: total={total} ({', '.join(parts)})"
+        else:
+            ent_line = "Entities: -"
+        lines.append(ent_line)
+
+        if t.extras:
+            for k, v in sorted(t.extras.items()):
+                lines.append(f"{k}: {v}")
+
+        self._cached_lines = lines
+        self._cache_invalid = False
+        return list(lines)
+
+    # ------------- Utility -------------
+    def invalidate(self) -> None:
+        self._cache_invalid = True
+
+
+__all__ = [
+    "DebugOverlay",
+    "GameTelemetry",
+    "OverlayStyle",
+    "FPSCounter",
+]

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -1,0 +1,94 @@
+import math
+
+import pytest
+
+from amor.debug.overlay import DebugOverlay, GameTelemetry, FPSCounter
+
+
+def test_toggle_with_f3_key(monkeypatch):
+    # Simulate arcade.key.F3 without importing arcade in environments lacking GL
+    class DummyArcade:
+        class key:
+            F3 = 114  # arbitrary unique code
+
+    # Patch module arcade in overlay to our dummy
+    import amor.debug.overlay as overlay_mod
+
+    original_arcade = overlay_mod.arcade
+    overlay_mod.arcade = DummyArcade
+    try:
+        overlay = DebugOverlay(enabled=False)
+        assert not overlay.enabled
+        overlay.on_key_press(DummyArcade.key.F3, 0)
+        assert overlay.enabled
+        overlay.on_key_press(DummyArcade.key.F3, 0)
+        assert not overlay.enabled
+    finally:
+        overlay_mod.arcade = original_arcade
+
+
+def test_compose_lines_contains_expected_fields():
+    tel = GameTelemetry(seed=123456789, floor=7)
+    tel.update_entities({"mobs": 5, "items": 3, "projectiles": 2})
+    tel.set_extra("Room", "BSP-23")
+    overlay = DebugOverlay(telemetry=tel, enabled=True)
+
+    # Simulate a couple frames to get non-zero FPS
+    overlay.on_update(0.016)
+    overlay.on_update(0.016)
+
+    lines = overlay.compose_lines()
+
+    assert any(line.startswith("FPS:") for line in lines)
+    assert any("Seed:" in line and "123456789" in line for line in lines)
+    assert any("Floor:" in line and "7" in line for line in lines)
+    ent_line = next(line for line in lines if line.startswith("Entities:"))
+    assert "total=10" in ent_line
+    assert "items=3" in ent_line and "mobs=5" in ent_line and "projectiles=2" in ent_line
+    assert any(line.startswith("Room:") and "BSP-23" in line for line in lines)
+
+
+def test_compose_lines_when_missing_values():
+    overlay = DebugOverlay(telemetry=GameTelemetry(), enabled=True)
+    lines = overlay.compose_lines()
+    # Default placeholders
+    assert any("Seed:" in line and "-" in line for line in lines)
+    assert any("Floor:" in line and "-" in line for line in lines)
+    assert any(line.strip() == "Entities: -" for line in lines)
+
+
+def test_fps_counter_accuracy():
+    fps = FPSCounter(time_window=1.0)
+
+    # 60 FPS simulation for ~1 second
+    for _ in range(60):
+        fps.update(1.0 / 60.0)
+    assert 55.0 <= fps.fps <= 65.0
+
+    # 30 FPS simulation
+    fps.reset()
+    for _ in range(30):
+        fps.update(1.0 / 30.0)
+    assert 25.0 <= fps.fps <= 35.0
+
+    # dt zero should not blow up
+    before = fps.fps
+    fps.update(0.0)
+    assert fps.fps == before
+
+
+def test_overlay_line_cache_invalidation():
+    tel = GameTelemetry(seed=1, floor=1)
+    overlay = DebugOverlay(telemetry=tel, enabled=True)
+
+    # Initial compose
+    lines1 = overlay.compose_lines()
+
+    # After on_update, FPS changed, lines should be recomposed (cache invalidated)
+    overlay.on_update(0.5)
+    lines2 = overlay.compose_lines()
+
+    # We can't guarantee visual diff, but lists should be separate objects and not crash
+    assert lines1 is not lines2
+
+


### PR DESCRIPTION
Automated implementation for issue #70:

Implementation summary:
- Added a standalone, production-ready debug overlay system under src/amor/debug/overlay.py with the following components:
  - DebugOverlay: Main class that composes and draws overlay information. It toggles on F3, shows FPS, seed, floor, and entity counts, and renders a translucent background for legibility. It gracefully no-ops when Arcade or an active window is unavailable.
  - GameTelemetry: A simple data holder for seed, floor, entity_counts, and optional extra key-values.
  - FPSCounter: Rolling FPS estimator independent of Arcade, so tests can run headless.
  - OverlayStyle: Customizable styling (font, colors, margins, padding, anchor).

Architecture and integration:
- Designed to integrate with an Arcade Window/Scene by calling on_update, on_draw, and on_key_press. Overlay pulls FPS from Arcade if available; otherwise uses its internal FPSCounter.
- Compose and render concerns are separated: compose_lines() returns the string lines for testing and logging, while on_draw() handles Arcade rendering. This avoids fragile GL-bound tests.
- Overlay computes a legible background box sized to content with padding and supports anchoring at any corner. It uses a monospaced font by default for alignment.

Robustness:
- Defensive checks for missing Arcade context, with logging and no exceptions.
- Entity count handling works with either a mapping or an iterable of categories.
- Caching of composed lines with automatic invalidation on updates for efficiency.

Tests:
- tests/test_debug_overlay.py covers:
  - Toggling via F3 key (with an injected dummy arcade.key to avoid GL requirements).
  - Composition of lines with expected fields and correct entity total formatting.
  - Placeholder rendering when telemetry values are missing.
  - FPSCounter behavior and reset handling.
  - Cache invalidation on update.

How to integrate in the game loop:
- Instantiate DebugOverlay and keep it as part of your scene/window state.
- On each frame, call overlay.on_update(dt) and overlay.on_draw() after drawing the world.
- Forward key events to overlay.on_key_press() to enable F3 toggling.
- Update overlay.telemetry.seed, overlay.telemetry.floor, and overlay.telemetry.update_entities(...) from your dungeon/world state. This satisfies the acceptance criteria of showing FPS, seed, floor, and entity counts, and toggling on/off.

Notes on dependencies and compatibility:
- The code avoids hard dependence on a live Arcade window during tests. If the project already has an input and render pipeline, only minimal wiring is needed.
- The overlay is self-contained and does not break existing architecture; it follows separation of concerns and is easily extensible (extras field) for future telemetry (e.g., RNG state, portal chance, memory usage).


Files created:
- src/amor/__init__.py
- src/amor/debug/__init__.py
- src/amor/debug/overlay.py
- tests/test_debug_overlay.py