### PR TITLE
Build App: Config & save directories

### DIFF
--- a/docs/paths-and-migration.md
+++ b/docs/paths-and-migration.md
@@ -1,0 +1,38 @@
+Amor Mortuorum: Platform-appropriate directories and migration
+
+Overview
+- Uses platformdirs to resolve OS-correct folders for config, saves (user data), logs, and cache.
+- Supports environment overrides for testing and power users:
+  - AMOR_CONFIG_DIR, AMOR_SAVE_DIR, AMOR_LOG_DIR, AMOR_CACHE_DIR
+- Migrates content from repository scaffolding directories if present:
+  - ./configs -> user_config_dir
+  - ./data/saves or ./saves -> user_data_dir/saves
+
+Locations by platform (via platformdirs)
+- Windows:
+  - Config: %APPDATA%/Amor Mortuorum
+  - Saves: %LOCALAPPDATA%/Amor Mortuorum/saves
+  - Logs: %LOCALAPPDATA%/Amor Mortuorum/logs
+  - Cache: %LOCALAPPDATA%/Amor Mortuorum/Cache
+- macOS:
+  - Config: ~/Library/Application Support/Amor Mortuorum
+  - Saves: ~/Library/Application Support/Amor Mortuorum/saves
+  - Logs: ~/Library/Logs/Amor Mortuorum (or within Application Support depending on platformdirs)
+  - Cache: ~/Library/Caches/Amor Mortuorum
+- Linux/BSD:
+  - Config: ~/.config/Amor Mortuorum
+  - Saves: ~/.local/share/Amor Mortuorum/saves
+  - Logs: ~/.local/state/Amor Mortuorum/logs (if available) or ~/.local/share/Amor Mortuorum/logs
+  - Cache: ~/.cache/Amor Mortuorum
+
+Migration behavior
+- If destination does not exist, files/directories are moved as-is.
+- If destination exists:
+  - Directory vs directory: recursively merge.
+  - File vs file: if identical, the source is dropped; if different, the source is preserved with a .migrated timestamp and placed next to the destination.
+- Empty scaffolding directories are pruned.
+- A .migration.log is appended in the destination to record actions.
+
+Usage
+- Call initialize_app_paths() early during application startup. It ensures directories then migrates any scaffolding contents.
+- For deterministic tests, set environment overrides to temporary directories.

--- a/src/amormortuorum/__init__.py
+++ b/src/amormortuorum/__init__.py
@@ -1,9 +1,8 @@
-"""
-Amor Mortuorum package root.
-"""
+from __future__ import annotations
 
 __all__ = [
     "__version__",
 ]
 
+# Version is managed here for easy tooling access
 __version__ = "0.1.0"

--- a/src/amormortuorum/io/__init__.py
+++ b/src/amormortuorum/io/__init__.py
@@ -1,0 +1,1 @@
+# Namespace package for IO utilities

--- a/src/amormortuorum/io/paths.py
+++ b/src/amormortuorum/io/paths.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+try:
+    # platformdirs is the modern successor to appdirs
+    from platformdirs import PlatformDirs
+except Exception as exc:  # pragma: no cover - defensive import error path
+    raise RuntimeError(
+        "platformdirs is required for amormortuorum.io.paths. Add platformdirs to your dependencies."
+    ) from exc
+
+
+LOGGER = logging.getLogger("amormortuorum.io.paths")
+LOGGER.addHandler(logging.NullHandler())
+
+APP_NAME = "Amor Mortuorum"
+
+# Environment variable overrides (useful for tests and power users)
+ENV_CONFIG_DIR = "AMOR_CONFIG_DIR"
+ENV_SAVE_DIR = "AMOR_SAVE_DIR"
+ENV_LOG_DIR = "AMOR_LOG_DIR"
+ENV_CACHE_DIR = "AMOR_CACHE_DIR"
+
+
+@dataclass
+class MigrationAction:
+    category: str  # "config" or "saves" or other
+    src: Optional[Path]
+    dest: Path
+    moved_files: list[Path]
+    skipped_files: list[Path]
+    renamed_files: list[tuple[Path, Path]]
+    errors: list[str]
+
+
+@dataclass
+class MigrationResult:
+    actions: list[MigrationAction]
+
+    @property
+    def migrated(self) -> bool:
+        return any(a.moved_files or a.renamed_files for a in self.actions)
+
+
+class AppPaths:
+    """Resolve and manage platform-appropriate directories for the app.
+
+    Provides:
+    - config_dir: user configuration files (YAML/JSON settings, keybindings, etc.)
+    - save_dir: user data files (save slots, persistent meta progression)
+    - log_dir: user log files directory
+    - cache_dir: derived or cached data
+
+    Behavior:
+    - Uses platformdirs for cross-platform correctness.
+    - Supports environment variable overrides for testing and portability.
+    - Migrates content from common scaffolding directories to the proper locations.
+    """
+
+    def __init__(self, app_name: str = APP_NAME) -> None:
+        self._dirs = PlatformDirs(appname=app_name, appauthor=False)
+
+        # Compute directories with overrides
+        self._config_dir = self._compute_dir(ENV_CONFIG_DIR, Path(self._dirs.user_config_dir))
+        # Saves are placed under the platform-specific user data dir in a "saves" subdirectory
+        self._save_dir = self._compute_dir(ENV_SAVE_DIR, Path(self._dirs.user_data_dir) / "saves")
+        # Logs
+        # platformdirs provides user_log_dir in newer versions; if missing, fallback to data/logs
+        default_log_dir = getattr(self._dirs, "user_log_dir", None) or (Path(self._dirs.user_data_dir) / "logs")
+        self._log_dir = self._compute_dir(ENV_LOG_DIR, Path(default_log_dir))
+        # Cache
+        self._cache_dir = self._compute_dir(ENV_CACHE_DIR, Path(self._dirs.user_cache_dir))
+
+    @staticmethod
+    def _compute_dir(env_var: str, default: Path) -> Path:
+        override = os.getenv(env_var)
+        if override:
+            return Path(override).expanduser().resolve()
+        return Path(default).expanduser().resolve()
+
+    @property
+    def config_dir(self) -> Path:
+        return self._config_dir
+
+    @property
+    def save_dir(self) -> Path:
+        return self._save_dir
+
+    @property
+    def log_dir(self) -> Path:
+        return self._log_dir
+
+    @property
+    def cache_dir(self) -> Path:
+        return self._cache_dir
+
+    def ensure_dirs(self) -> None:
+        """Create all app directories if they don't exist, with sensible permissions."""
+        for d in (self.config_dir, self.save_dir, self.log_dir, self.cache_dir):
+            d.mkdir(parents=True, exist_ok=True)
+        self._write_dir_readme(self.config_dir, "Configuration files for Amor Mortuorum.")
+        self._write_dir_readme(self.save_dir, "Save files for Amor Mortuorum.")
+        self._write_dir_readme(self.log_dir, "Log files for Amor Mortuorum.")
+        self._write_dir_readme(self.cache_dir, "Cache for Amor Mortuorum (safe to delete).")
+
+    def migrate_from_scaffold(self, scaffold_root: Optional[Path] = None) -> MigrationResult:
+        """Migrate configs and saves from common repository scaffolding directories.
+
+        This supports moving from a dev layout like:
+        - ./configs -> config_dir
+        - ./data/saves or ./saves -> save_dir
+
+        Migration is conservative: existing destination files are preserved; files are only
+        moved if they don't already exist. If a conflicting file exists, the source file is
+        preserved with a .migrated timestamp suffix.
+        """
+        root = self._resolve_scaffold_root(scaffold_root)
+        self.ensure_dirs()
+
+        actions: list[MigrationAction] = []
+
+        # Candidates (first match wins) relative to root
+        config_candidates = [
+            root / "configs",
+            root / "config",
+            root / "settings",
+        ]
+        save_candidates = [
+            root / "data" / "saves",
+            root / "saves",
+            root / "savegames",
+        ]
+
+        actions.append(self._migrate_category("config", config_candidates, self.config_dir))
+        actions.append(self._migrate_category("saves", save_candidates, self.save_dir))
+
+        return MigrationResult(actions=actions)
+
+    # --------------------- Internal helpers ---------------------
+
+    def _resolve_scaffold_root(self, explicit: Optional[Path]) -> Path:
+        if explicit:
+            return Path(explicit).expanduser().resolve()
+        # Prefer current working directory; fall back to the project root if run from package
+        cwd = Path.cwd()
+        if (cwd / "configs").exists() or (cwd / "data").exists():
+            return cwd
+        # Attempt to find a repo root relative to this file (two levels up from src package)
+        pkg_root = Path(__file__).resolve().parents[3] if len(Path(__file__).resolve().parents) >= 4 else Path(__file__).resolve().parent
+        return pkg_root
+
+    def _migrate_category(
+        self, category: str, src_candidates: Iterable[Path], dest_dir: Path
+    ) -> MigrationAction:
+        chosen_src: Optional[Path] = None
+        for c in src_candidates:
+            if c.exists() and self._has_content(c):
+                chosen_src = c
+                break
+
+        moved: list[Path] = []
+        skipped: list[Path] = []
+        renamed: list[tuple[Path, Path]] = []
+        errors: list[str] = []
+
+        if not chosen_src:
+            # Nothing to migrate
+            return MigrationAction(category, None, dest_dir, moved, skipped, renamed, errors)
+
+        LOGGER.info("Migrating %s from '%s' -> '%s'", category, chosen_src, dest_dir)
+        # Merge/move contents into dest
+        try:
+            for src_child in sorted(chosen_src.iterdir()):
+                try:
+                    result = self._move_or_merge(src_child, dest_dir / src_child.name)
+                    moved.extend(result["moved"])  # type: ignore[index]
+                    skipped.extend(result["skipped"])  # type: ignore[index]
+                    renamed.extend(result["renamed"])  # type: ignore[index]
+                except Exception as move_exc:  # pragma: no cover - defensive path
+                    msg = f"Failed to migrate '{src_child}': {move_exc}"
+                    LOGGER.exception(msg)
+                    errors.append(msg)
+            # Clean up empty directories left behind
+            self._prune_if_empty(chosen_src)
+            # Write migration log into destination
+            self._write_migration_log(dest_dir, chosen_src, moved, skipped, renamed, errors)
+        except Exception as exc:  # pragma: no cover - defensive path
+            msg = f"Migration for {category} failed: {exc}"
+            LOGGER.exception(msg)
+            errors.append(msg)
+
+        return MigrationAction(category, chosen_src, dest_dir, moved, skipped, renamed, errors)
+
+    @staticmethod
+    def _has_content(p: Path) -> bool:
+        if not p.exists():
+            return False
+        if p.is_file():
+            return p.stat().st_size > 0
+        # Directory: has any items
+        return any(p.iterdir())
+
+    def _move_or_merge(self, src: Path, dest: Path) -> dict[str, list]:
+        """Move a file or directory from src into dest, merging if needed.
+
+        - If dest doesn't exist, move src -> dest.
+        - If dest exists:
+          - For directories: recursively merge children.
+          - For files: if identical, skip; otherwise, preserve destination and rename source with a .migrated timestamp.
+        Returns dict of moved/skipped/renamed paths.
+        """
+        moved: list[Path] = []
+        skipped: list[Path] = []
+        renamed: list[tuple[Path, Path]] = []
+
+        if not dest.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dest))
+            moved.append(dest)
+            return {"moved": moved, "skipped": skipped, "renamed": renamed}
+
+        # Both exist
+        if src.is_dir() and dest.is_dir():
+            # Merge every child recursively
+            for child in sorted(src.iterdir()):
+                child_result = self._move_or_merge(child, dest / child.name)
+                moved.extend(child_result["moved"])  # type: ignore[index]
+                skipped.extend(child_result["skipped"])  # type: ignore[index]
+                renamed.extend(child_result["renamed"])  # type: ignore[index]
+            # Remove empty directory
+            self._prune_if_empty(src)
+            return {"moved": moved, "skipped": skipped, "renamed": renamed}
+
+        if src.is_file() and dest.is_file():
+            if self._files_identical(src, dest):
+                # Same content, drop source duplicate
+                skipped.append(dest)
+                try:
+                    src.unlink(missing_ok=True)
+                except Exception:  # pragma: no cover - defensive path
+                    LOGGER.debug("Failed to unlink duplicate source file '%s'", src)
+                return {"moved": moved, "skipped": skipped, "renamed": renamed}
+            # Conflict: preserve destination, rename source with .migrated suffix
+            ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+            migrated_name = f"{src.name}.migrated.{ts}"
+            migrated_path = src.with_name(migrated_name)
+            src.rename(migrated_path)
+            # Move the renamed file next to the destination for visibility
+            final_migrated = dest.with_name(migrated_name)
+            shutil.move(str(migrated_path), str(final_migrated))
+            renamed.append((dest, final_migrated))
+            return {"moved": moved, "skipped": skipped, "renamed": renamed}
+
+        # One is file and the other is directory -> rename source and move
+        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        migrated_name = f"{src.name}.migrated.{ts}"
+        migrated_src = src.with_name(migrated_name)
+        src.rename(migrated_src)
+        final_migrated = dest.with_name(migrated_name)
+        shutil.move(str(migrated_src), str(final_migrated))
+        renamed.append((dest, final_migrated))
+        return {"moved": moved, "skipped": skipped, "renamed": renamed}
+
+    @staticmethod
+    def _files_identical(a: Path, b: Path) -> bool:
+        try:
+            if a.stat().st_size != b.stat().st_size:
+                return False
+        except FileNotFoundError:
+            return False
+        # Hash both (small files typical for configs/saves)
+        return AppPaths._md5(a) == AppPaths._md5(b)
+
+    @staticmethod
+    def _md5(p: Path, chunk_size: int = 65536) -> str:
+        h = hashlib.md5()
+        with p.open("rb") as f:
+            while True:
+                chunk = f.read(chunk_size)
+                if not chunk:
+                    break
+                h.update(chunk)
+        return h.hexdigest()
+
+    @staticmethod
+    def _prune_if_empty(p: Path) -> None:
+        try:
+            if p.is_dir() and not any(p.iterdir()):
+                p.rmdir()
+                # attempt to prune parent if looks like a scaffold dir
+                if p.parent.name in {"data", "configs", "config"} and not any(p.parent.iterdir()):
+                    p.parent.rmdir()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            LOGGER.debug("Could not prune '%s' (may be non-empty or lacking permissions)", p)
+
+    @staticmethod
+    def _write_dir_readme(d: Path, description: str) -> None:
+        readme = d / "README.txt"
+        if readme.exists():
+            return
+        msg = (
+            f"{description}\n\n"
+            f"This directory was created by Amor Mortuorum to follow platform-appropriate\n"
+            f"storage conventions using platformdirs.\n"
+        )
+        try:
+            readme.write_text(msg, encoding="utf-8")
+        except Exception:  # pragma: no cover - non-critical
+            LOGGER.debug("Failed to write README to '%s'", readme)
+
+    @staticmethod
+    def _write_migration_log(dest_dir: Path, src_dir: Path, moved: list[Path], skipped: list[Path], renamed: list[tuple[Path, Path]], errors: list[str]) -> None:
+        log_path = dest_dir / ".migration.log"
+        lines = [
+            f"[{datetime.utcnow().isoformat()}Z] Migration from '{src_dir}'\n",
+            f"Moved: {len(moved)} files\n",
+            f"Skipped (identical): {len(skipped)} files\n",
+            f"Renamed (conflicts): {len(renamed)} files\n",
+        ]
+        if errors:
+            lines.append(f"Errors: {len(errors)}\n")
+            for e in errors:
+                lines.append(f"- {e}\n")
+        lines.append("\n")
+        try:
+            with log_path.open("a", encoding="utf-8") as f:
+                f.writelines(lines)
+        except Exception:  # pragma: no cover - non-critical
+            LOGGER.debug("Failed to append migration log to '%s'", log_path)
+
+
+def initialize_app_paths(scaffold_root: Optional[Path] = None) -> AppPaths:
+    """Initialize and migrate directories. Call this early in application startup.
+
+    Returns an AppPaths instance with platform-correct directories ensured and migrated.
+
+    Environment overrides can be used to redirect directories (e.g., in tests):
+    - AMOR_CONFIG_DIR
+    - AMOR_SAVE_DIR
+    - AMOR_LOG_DIR
+    - AMOR_CACHE_DIR
+    """
+    paths = AppPaths()
+    paths.ensure_dirs()
+    result = paths.migrate_from_scaffold(scaffold_root)
+    if result.migrated:
+        LOGGER.info("Completed migration into platform directories.")
+    return paths

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from amormortuorum.io.paths import AppPaths, initialize_app_paths
+
+
+@pytest.fixture()
+def tmp_env(tmp_path, monkeypatch):
+    # Force platform directories to use our temp dirs via overrides
+    config = tmp_path / "user_config"
+    data = tmp_path / "user_data"
+    logs = tmp_path / "user_logs"
+    cache = tmp_path / "user_cache"
+    monkeypatch.setenv("AMOR_CONFIG_DIR", str(config))
+    monkeypatch.setenv("AMOR_SAVE_DIR", str(data / "saves"))
+    monkeypatch.setenv("AMOR_LOG_DIR", str(logs))
+    monkeypatch.setenv("AMOR_CACHE_DIR", str(cache))
+    return {
+        "config": config,
+        "data": data,
+        "logs": logs,
+        "cache": cache,
+    }
+
+
+def test_environment_overrides_are_used(tmp_env):
+    paths = AppPaths()
+    paths.ensure_dirs()
+
+    assert paths.config_dir == tmp_env["config"].resolve()
+    assert paths.save_dir == (tmp_env["data"] / "saves").resolve()
+    assert paths.log_dir == tmp_env["logs"].resolve()
+    assert paths.cache_dir == tmp_env["cache"].resolve()
+
+    # Ensure directories exist
+    assert paths.config_dir.exists()
+    assert paths.save_dir.exists()
+    assert paths.log_dir.exists()
+    assert paths.cache_dir.exists()
+
+
+def test_migrate_from_scaffold_config_and_saves(tmp_path, tmp_env):
+    # Create a scaffold layout
+    scaffold = tmp_path / "project"
+    configs = scaffold / "configs"
+    saves = scaffold / "data" / "saves"
+    configs.mkdir(parents=True)
+    saves.mkdir(parents=True)
+
+    # Create sample files
+    (configs / "settings.yaml").write_text("foo: 1\n", encoding="utf-8")
+    (saves / "slot1.sav").write_text("SAVE_DATA", encoding="utf-8")
+
+    paths = initialize_app_paths(scaffold)
+
+    # Files should be migrated
+    assert (paths.config_dir / "settings.yaml").exists()
+    assert (paths.save_dir / "slot1.sav").exists()
+
+    # Source should be pruned if empty
+    assert not configs.exists() or not any(configs.iterdir())
+    # Saves parent may still exist, but saves directory should be pruned or empty
+    assert not saves.exists() or not any(saves.iterdir())
+
+
+def test_migration_is_conservative_on_conflicts(tmp_path, tmp_env):
+    scaffold = tmp_path / "project"
+    (scaffold / "configs").mkdir(parents=True)
+
+    # Destination already has a settings.yaml with new content
+    paths = AppPaths()
+    paths.ensure_dirs()
+
+    dest_settings = paths.config_dir / "settings.yaml"
+    dest_settings.write_text("foo: NEW\n", encoding="utf-8")
+
+    # Source has conflicting file
+    src_settings = scaffold / "configs" / "settings.yaml"
+    src_settings.write_text("foo: OLD\n", encoding="utf-8")
+
+    result = paths.migrate_from_scaffold(scaffold)
+
+    # Destination file should be preserved
+    assert dest_settings.read_text(encoding="utf-8") == "foo: NEW\n"
+    # A migrated copy should exist with suffix
+    migrated_candidates = list(paths.config_dir.glob("settings.yaml.migrated.*"))
+    assert len(migrated_candidates) == 1
+
+    # Migration result should report activity
+    assert result.migrated is True
+
+
+def test_identical_files_result_in_skip(tmp_path, tmp_env):
+    # Setup identical file in dest and src
+    scaffold = tmp_path / "project"
+    (scaffold / "configs").mkdir(parents=True)
+
+    paths = AppPaths()
+    paths.ensure_dirs()
+
+    src = scaffold / "configs" / "keybinds.json"
+    dst = paths.config_dir / "keybinds.json"
+
+    content = '{"a":"b"}\n'
+    src.write_text(content, encoding="utf-8")
+    dst.write_text(content, encoding="utf-8")
+
+    result = paths.migrate_from_scaffold(scaffold)
+
+    # No migrated copy should be created, destination preserved, source removed
+    assert dst.exists()
+    assert not src.exists()
+    # Verify at least one action had a skipped file
+    assert any(a.skipped_files for a in result.actions)
+
+
+def test_saves_migration_from_top_level_saves_dir(tmp_path, tmp_env):
+    scaffold = tmp_path / "project"
+    (scaffold / "saves").mkdir(parents=True)
+    (scaffold / "saves" / "slot2.sav").write_text("DATA", encoding="utf-8")
+
+    paths = AppPaths()
+    paths.ensure_dirs()
+
+    paths.migrate_from_scaffold(scaffold)
+
+    assert (paths.save_dir / "slot2.sav").exists()


### PR DESCRIPTION
Automated implementation for issue #74:

Summary
This implementation introduces a robust, cross-platform directory management and migration system for Amor Mortuorum. It ensures configuration and save data are stored in OS-appropriate locations (Windows AppData, macOS Library/Application Support, Linux ~/.config and ~/.local/share) and migrates data from the repository scaffold (e.g., ./configs and ./data/saves) when necessary.

Key capabilities
- Platform-appropriate directories via platformdirs: config, saves (data), logs, and cache.
- Environment overrides (AMOR_CONFIG_DIR, AMOR_SAVE_DIR, AMOR_LOG_DIR, AMOR_CACHE_DIR) for testing and power users.
- Conservative migration from scaffold locations with comprehensive handling:
  - First-match candidate detection for config and saves.
  - Recursive merge for directories.
  - Conflict-safe file handling: preserve destination; rename source with a .migrated.<timestamp> suffix.
  - Duplicate detection using MD5 to avoid unnecessary duplication.
  - Prunes empty scaffold directories and writes a migration log .migration.log in the destination.
- Initialization helper initialize_app_paths to be called during app startup.

Architecture decisions
- A dedicated AppPaths class encapsulates path resolution, directory creation, and migration logic to centralize storage concerns and simplify integration across the codebase.
- platformdirs is used instead of manually branching on platform/system APIs, reducing edge cases and making behavior consistent with OS guidelines.
- Environment overrides enable deterministic unit testing without relying on the host OS, while also offering power users a way to relocate storage.
- Migration is written as a merge operation to avoid destructive overwrites.

Integration points
- Call initialize_app_paths() at application boot to ensure directories and trigger one-time migration. The returned AppPaths instance provides the resolved config_dir, save_dir, log_dir, and cache_dir that other subsystems should use.
- Replace any hard-coded references to ./configs and ./data/saves with paths.config_dir and paths.save_dir from the AppPaths instance.

Testing
- tests/test_paths.py validates:
  - Environment variable overrides.
  - Migration from common scaffold locations.
  - Conservative handling of file conflicts and duplicate content.
  - Top-level saves directory migration.

Notes
- If your existing code expects specific file names (e.g., settings.yaml) under ./configs, ensure it now reads from AppPaths.config_dir.
- The module writes small README.txt files in managed directories for clarity and a .migration.log during migrations.



Files created:
- src/amormortuorum/__init__.py
- src/amormortuorum/io/__init__.py
- src/amormortuorum/io/paths.py
- tests/test_paths.py
- docs/paths-and-migration.md