### PR TITLE
Build App: CI pipeline for lint/test/build

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,21 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+exclude = 
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    build,
+    dist,
+    .eggs,
+    .mypy_cache,
+    .pytest_cache,
+    pyinstaller,
+    data,
+    docs/_build
+per-file-ignores =
+    tests/*: D,S101
+
+# Enable useful plugins if they exist (safe to ignore otherwise)
+select = C,E,F,W,B,B9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,131 @@
+name: CI / Lint / Test / Build
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  actions: read
+  checks: write
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYGLET_HEADLESS: 'true'
+  SDL_VIDEODRIVER: dummy
+  PYTHONUNBUFFERED: '1'
+  FORCE_COLOR: '1'
+
+jobs:
+  lint_and_test:
+    name: Lint and Test (Linux, Py3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt', 'pyproject.toml', 'setup.cfg', 'setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install base tooling
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install flake8 pytest pytest-cov
+
+      - name: Install project (editable if possible)
+        shell: bash
+        run: |
+          set -e
+          if [ -f pyproject.toml ] || [ -f setup.py ]; then
+            python -m pip install -e . || python -m pip install .
+          elif [ -f requirements.txt ]; then
+            python -m pip install -r requirements.txt
+          fi
+
+      - name: Flake8 Lint
+        run: flake8 .
+
+      - name: Run tests
+        env:
+          HEADLESS: '1'
+        run: pytest -q --maxfail=1 --disable-warnings
+
+  build:
+    name: Build binaries (tagged) [${{ matrix.os }}]
+    needs: lint_and_test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python-version: [ '3.11' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt', 'pyproject.toml', 'setup.cfg', 'setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install pyinstaller build
+
+      - name: Install project
+        run: |
+          if [ -f pyproject.toml ] || [ -f setup.py ]; then
+            python -m pip install .
+          elif [ -f requirements.txt ]; then
+            python -m pip install -r requirements.txt
+          fi
+        shell: bash
+
+      - name: Build binary with PyInstaller (auto-detect)
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          python tools/ci/build_binary.py --name "AmorMortuorum" --out dist/release
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ runner.os }}
+          path: dist/release/*
+          if-no-files-found: error
+
+      - name: Upload assets to GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            dist/release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,38 @@
+CI / CD and Release Pipeline
+
+Overview
+- Linting: flake8 enforces style and static checks.
+- Tests: pytest runs the unit test suite headlessly.
+- Build: On tags (v*), PyInstaller builds standalone binaries for Linux, Windows, and macOS. Artifacts are uploaded to the GitHub Release and stored as workflow artifacts.
+
+How it works
+1. Triggers
+   - push to main and pull requests: run lint and tests
+   - push tags matching v*: run lint/tests first, then build and upload artifacts for three platforms
+
+2. Lint & Test
+   - Uses Python 3.11 on Ubuntu
+   - Installs the project and dev tools (flake8, pytest)
+   - Headless-friendly environment variables are set for graphics libs
+
+3. Build
+   - Matrix across ubuntu-latest, windows-latest, macos-latest
+   - Installs PyInstaller and the project
+   - Auto-detection for the entry point:
+     - If a PyInstaller spec exists in pyinstaller/*.spec, it is used
+     - Otherwise, [project.scripts] from pyproject.toml is parsed, and the corresponding module is used
+     - Otherwise, src/**/__main__.py is used
+   - Produces a single-file binary and zips it with README and LICENSE
+   - Artifact name: AmorMortuorum-<version>-<platform>.zip
+
+4. Release Upload
+   - Tag pushes (refs/tags/v*) upload all artifacts to the corresponding GitHub Release
+   - Artifacts are also uploaded as workflow artifacts for later inspection
+
+Customization
+- Change the application/binary name by editing the --name argument in the build step or invoking tools/ci/build_binary.py directly.
+- Provide a custom PyInstaller spec in pyinstaller/*.spec to fully control packaging.
+
+Notes
+- If your project requires platform-specific build dependencies (SDL, OpenGL, etc.), install them before running PyInstaller by adding steps to the build job.
+- Codesigning and notarization (macOS) are out of scope for the default pipeline but can be added as follow-up work.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+addopts = -q
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning
+
+# Markers placeholders (tests may or may not use these)
+markers =
+    integration: marks tests as integration (deselect with '-m "not integration"')
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_build_binary.py
+++ b/tests/test_build_binary.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import sys
+
+from tools.ci.build_binary import (
+    find_spec_file,
+    parse_pyproject_entrypoint,
+    resolve_module_file,
+    detect_entrypoint,
+    platform_tag,
+)
+
+
+def test_find_spec_file(tmp_path: Path):
+    (tmp_path / "pyinstaller").mkdir()
+    spec = tmp_path / "pyinstaller" / "app.spec"
+    spec.write_text("# spec content", encoding="utf-8")
+    assert find_spec_file(tmp_path) == spec
+
+
+def test_parse_pyproject_entrypoint(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+        [project]
+        name = "demo"
+        version = "0.1.0"
+
+        [project.scripts]
+        demo = "pkg.cli:main"
+        """,
+        encoding="utf-8",
+    )
+    ep = parse_pyproject_entrypoint(pyproject)
+    assert ep == "pkg.cli:main"
+
+
+def test_resolve_module_file_and_detect_entrypoint(tmp_path: Path, monkeypatch):
+    # Create a minimal package with a script module
+    src = tmp_path / "src"
+    pkg = src / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("__all__ = []\n", encoding="utf-8")
+    (pkg / "cli.py").write_text("def main():\n    pass\n", encoding="utf-8")
+
+    # Ensure import works
+    monkeypatch.syspath_prepend(str(src))
+
+    # Module path
+    mod_file = resolve_module_file("pkg.cli:main")
+    assert mod_file is not None
+    assert mod_file.name == "cli.py"
+
+    # Fallback detect from src/**/__main__.py when no scripts
+    (pkg / "__main__.py").write_text("print('ok')\n", encoding="utf-8")
+    ep = detect_entrypoint(tmp_path)
+    assert ep is not None
+    assert ep.name == "__main__.py"
+
+
+def test_platform_tag_has_os_and_arch():
+    tag = platform_tag()
+    assert any(tag.startswith(os) for os in ("linux-", "windows-", "macos-"))
+    assert any(tag.endswith(arch) for arch in ("x86_64", "arm64"))

--- a/tools/ci/__init__.py
+++ b/tools/ci/__init__.py
@@ -1,0 +1,4 @@
+"""CI utilities for building artifacts.
+
+This package contains helper scripts used by the CI workflows.
+"""

--- a/tools/ci/build_binary.py
+++ b/tools/ci/build_binary.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Build a standalone binary using PyInstaller with sensible auto-detection.
+
+- Prefer a PyInstaller .spec file in ./pyinstaller/*.spec
+- Otherwise, try to detect an entry point via pyproject [project.scripts]
+- Otherwise, fall back to searching for src/**/__main__.py
+
+Outputs a zipped artifact named:
+  {name}-{version}-{platform}.zip
+under the provided --out directory (default: dist/release).
+
+This script is safe to import: its main logic runs only under __main__.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata as metadata
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple, List
+
+try:
+    import tomllib  # Python 3.11+
+except Exception:  # pragma: no cover - backport only if needed
+    tomllib = None  # type: ignore
+
+
+@dataclass
+class BuildPlan:
+    spec_file: Optional[Path]
+    entry_file: Optional[Path]
+    app_name: str
+
+
+def debug(msg: str) -> None:
+    print(f"[build_binary] {msg}")
+
+
+def get_version(default: str = "0.0.0") -> str:
+    """Extract version from GITHUB_REF tag, or installed package, or fallback.
+    """
+    # 1) From tag (e.g., refs/tags/v1.2.3)
+    ref = os.environ.get("GITHUB_REF", "")
+    m = re.match(r"refs/tags/v(?P<v>[0-9]+\.[0-9]+\.[0-9]+.*)", ref)
+    if m:
+        return m.group("v")
+
+    # 2) From installed package (best-effort)
+    for candidate in ("amor-mortuorum", "amor_mortuorum", "amormortuorum"):
+        try:
+            return metadata.version(candidate)
+        except metadata.PackageNotFoundError:
+            continue
+        except Exception:
+            break
+    return default
+
+
+def platform_tag() -> str:
+    sysname = platform.system().lower()
+    machine = platform.machine().lower()
+
+    # Normalize architecture
+    arch = "x86_64"
+    if machine in ("x86_64", "amd64"):  # Windows reports AMD64
+        arch = "x86_64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm64"
+
+    if sysname.startswith("darwin") or sysname == "mac" or sysname == "macos":
+        return f"macos-{arch}"
+    if sysname.startswith("win"):
+        return f"windows-{arch}"
+    return f"linux-{arch}"
+
+
+def find_spec_file(root: Path) -> Optional[Path]:
+    # Prefer ./pyinstaller/*.spec
+    pi = root / "pyinstaller"
+    if pi.exists():
+        specs = sorted(pi.glob("*.spec"))
+        if specs:
+            return specs[0]
+    # Fallback: any .spec
+    any_specs = sorted(root.glob("*.spec"))
+    if any_specs:
+        return any_specs[0]
+    # Deep search as last resort
+    for p in root.rglob("*.spec"):
+        return p
+    return None
+
+
+def parse_pyproject_entrypoint(pyproject: Path) -> Optional[str]:
+    if not pyproject.exists() or tomllib is None:
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    proj = data.get("project", {})
+    scripts = proj.get("scripts") or {}
+    if not isinstance(scripts, dict) or not scripts:
+        return None
+    # take first script command 'module:func'
+    first = next(iter(scripts.values()))
+    if isinstance(first, str) and ":" in first:
+        return first
+    return None
+
+
+def resolve_module_file(module_path: str) -> Optional[Path]:
+    """Resolve a "module.sub:func" to the module file path via importlib."""
+    mod_name = module_path.split(":", 1)[0]
+    try:
+        mod = importlib.import_module(mod_name)
+    except Exception:
+        return None
+    file = getattr(mod, "__file__", None)
+    if not file:
+        return None
+    return Path(file)
+
+
+def find_src_main(root: Path) -> Optional[Path]:
+    src = root / "src"
+    if not src.exists():
+        return None
+    candidates = list(src.rglob("__main__.py"))
+    if not candidates:
+        return None
+    # If multiple, prefer package names that look like the project
+    preferred = [
+        p for p in candidates if p.parent.name in ("amor_mortuorum", "amormortuorum", "game", "app")
+    ]
+    return preferred[0] if preferred else candidates[0]
+
+
+def detect_entrypoint(root: Path) -> Optional[Path]:
+    # Try pyproject scripts first
+    pp = root / "pyproject.toml"
+    ep = parse_pyproject_entrypoint(pp)
+    if ep:
+        mod_file = resolve_module_file(ep)
+        if mod_file and mod_file.exists():
+            return mod_file
+    # Fallback to src/**/__main__.py
+    return find_src_main(root)
+
+
+def run_pyinstaller_with_spec(spec_file: Path) -> None:
+    cmd = [sys.executable, "-m", "PyInstaller", str(spec_file)]
+    debug(f"Running PyInstaller with spec: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def run_pyinstaller_on_entry(entry_file: Path, name: str) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--clean",
+        "--onefile",
+        "--name",
+        name,
+        str(entry_file),
+    ]
+    debug(f"Running PyInstaller on entry: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def guess_built_binary(dist_dir: Path, preferred_name: Optional[str] = None) -> Optional[Path]:
+    if not dist_dir.exists():
+        return None
+
+    # If we know the name, check obvious candidates first
+    if preferred_name:
+        base = dist_dir / preferred_name
+        win = dist_dir / f"{preferred_name}.exe"
+        if base.exists() and base.is_file():
+            return base
+        if win.exists() and win.is_file():
+            return win
+        # One-folder
+        folder = dist_dir / preferred_name
+        if folder.exists() and folder.is_dir():
+            # executable inside folder
+            inner_win = folder / f"{preferred_name}.exe"
+            inner_unix = folder / preferred_name
+            if inner_win.exists():
+                return inner_win
+            if inner_unix.exists():
+                return inner_unix
+
+    # Otherwise: pick the most recently modified file in dist or one level deep
+    candidates: List[Path] = []
+    for p in dist_dir.glob("*"):
+        if p.is_file():
+            candidates.append(p)
+        elif p.is_dir():
+            for q in p.glob("*"):
+                if q.is_file():
+                    candidates.append(q)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
+def zip_artifact(binary: Path, out_dir: Path, name: str, version: str, plat: str) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    archive = out_dir / f"{name}-{version}-{plat}.zip"
+    import zipfile
+
+    root = Path.cwd()
+    readme = next((p for p in (root / "README.md", root / "readme.md") if p.exists()), None)
+    license_file = None
+    for candidate in ("LICENSE", "LICENSE.txt", "LICENSE.md", "COPYING", "COPYING.txt"):
+        p = root / candidate
+        if p.exists():
+            license_file = p
+            break
+
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(binary, arcname=binary.name)
+        if readme:
+            zf.write(readme, arcname=readme.name)
+        if license_file:
+            zf.write(license_file, arcname=license_file.name)
+    debug(f"Created artifact: {archive}")
+    return archive
+
+
+def prepare_environment() -> None:
+    # Ensure PyInstaller is available
+    if shutil.which("pyinstaller") is None:
+        debug("PyInstaller not found on PATH; attempting to install...")
+        subprocess.run([sys.executable, "-m", "pip", "install", "pyinstaller"], check=True)
+
+
+def make_build_plan(root: Path, name: str) -> BuildPlan:
+    spec = find_spec_file(root)
+    if spec is not None:
+        return BuildPlan(spec_file=spec, entry_file=None, app_name=name)
+    entry = detect_entrypoint(root)
+    return BuildPlan(spec_file=None, entry_file=entry, app_name=name)
+
+
+def build(plan: BuildPlan) -> Path:
+    prepare_environment()
+    dist_dir = Path.cwd() / "dist"
+    dist_dir.mkdir(exist_ok=True)
+
+    if plan.spec_file is not None:
+        debug(f"Using spec file: {plan.spec_file}")
+        run_pyinstaller_with_spec(plan.spec_file)
+        built = guess_built_binary(dist_dir, None)
+    else:
+        if plan.entry_file is None:
+            raise SystemExit("Could not detect an application entry point. Provide a .spec file or define [project.scripts] in pyproject.toml or add src/**/__main__.py")
+        debug(f"Using entry file: {plan.entry_file}")
+        run_pyinstaller_on_entry(plan.entry_file, plan.app_name)
+        built = guess_built_binary(dist_dir, plan.app_name)
+
+    if not built or not built.exists():
+        raise SystemExit("Build completed but no binary was found in dist/")
+    return built
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Build standalone binary and zip it for release")
+    parser.add_argument("--name", default="AmorMortuorum", help="Base application/binary name")
+    parser.add_argument("--out", default="dist/release", help="Output directory for zipped artifact")
+    args = parser.parse_args(argv)
+
+    root = Path.cwd()
+    plan = make_build_plan(root, args.name)
+
+    debug(f"Build plan: spec_file={plan.spec_file}, entry_file={plan.entry_file}, app_name={plan.app_name}")
+    binary = build(plan)
+
+    version = get_version()
+    plat = platform_tag()
+    out_dir = Path(args.out)
+    artifact = zip_artifact(binary, out_dir, args.name, version, plat)
+
+    # Write a pointer file for CI steps if needed
+    (out_dir / "artifacts.txt").write_text(str(artifact) + "\n", encoding="utf-8")
+    print(str(artifact))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Automated implementation for issue #75:

What was implemented:
- A complete GitHub Actions workflow (ci.yml) that:
  - Runs flake8 and pytest on pushes and PRs to main.
  - Builds standalone binaries on tag pushes (v*) for Linux, Windows, and macOS using PyInstaller.
  - Uploads build artifacts to both the workflow and the GitHub Release.
- A robust build helper (tools/ci/build_binary.py):
  - Auto-detects how to build the app: prefers a PyInstaller spec in pyinstaller/*.spec, else parses pyproject [project.scripts], else falls back to src/**/__main__.py.
  - Builds with PyInstaller and zips the binary with README and LICENSE.
  - Names artifacts in a release-friendly, platform-specific format (AmorMortuorum-<version>-<platform>.zip).
- Lint and test configuration:
  - .flake8 with sensible defaults and exclusions.
  - pytest.ini with quiet defaults and marker placeholders.
- Unit tests for the build utility covering spec discovery, entrypoint detection, and platform tagging.
- Documentation (docs/ci.md) explaining the pipeline, triggers, build strategy, and customization.

Architecture decisions:
- Single workflow handles lint/test for all pushes/PRs and gated build on tag pushes to keep the pipeline simple and fast.
- Leveraged a Python helper script to encapsulate complex detection logic rather than writing brittle inline bash in the workflow. This improves maintainability and testability.
- Artifact upload uses softprops/action-gh-release to attach build outputs to the tagged release, satisfying the acceptance criterion of having artifacts on tags for three platforms.

Integration points:
- If a PyInstaller spec already exists in the repository (pyinstaller/*.spec), the script and workflow will use it seamlessly.
- If the project declares a console script in pyproject.toml ([project.scripts]), that is auto-detected for building.
- Otherwise, a __main__.py under src is used to create a single-file binary.

Caveats:
- GUI frameworks on CI occasionally require additional system packages; the workflow sets headless-friendly env vars but real hardware acceleration is not required for building. Add platform-specific system deps as needed.
- macOS code signing/notarization is not configured and can be added later.


Files created:
- .github/workflows/ci.yml
- .flake8
- pytest.ini
- tools/__init__.py
- tools/ci/__init__.py
- tools/ci/build_binary.py
- tests/test_build_binary.py
- docs/ci.md